### PR TITLE
CASMNET-690 Add CMN for bifurcated CAN and make VLAN handling consistent

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -29,6 +29,7 @@ var validateCmd = &cobra.Command{
 			runCommand("ip a show bond0")
 			runCommand("ip a show vlan002")
 			runCommand("ip a show vlan004")
+			runCommand("ip a show vlan006")
 			runCommand("ip a show vlan007")
 		}
 

--- a/pkg/csi/config.go
+++ b/pkg/csi/config.go
@@ -34,6 +34,7 @@ type SystemConfig struct {
 	RpmRegistry     string   `form:"rpm-repository" mapstructure:"rpm-repository"`
 	NMNCidr         string   `form:"nmn-cidr" mapstructure:"nmn-cidr"`
 	HMNCidr         string   `form:"hmn-cidr" mapstructure:"hmn-cidr"`
+	CMNCidr         string   `form:"cmn-cidr" mapstructure:"cmn-cidr"`
 	CANCidr         string   `form:"can-cidr" mapstructure:"can-cidr"`
 	MTLCidr         string   `form:"mtl-cidr" mapstructure:"mtl-cidr"`
 	HSNCidr         string   `form:"hsn-cidr" mapstructure:"hsn-cidr"`

--- a/pkg/csi/defaults.go
+++ b/pkg/csi/defaults.go
@@ -55,6 +55,14 @@ const (
 	DefaultMacVlanString = "10.252.124.0/23"
 	// DefaultHSNString is the Default HSN String
 	DefaultHSNString = "10.253.0.0/16"
+	// DefaultCMNString is the Default CMN String (vlan006)
+	DefaultCMNString = "10.103.6.0/24"
+	// DefaultCMNPoolString is the default pool for CMN addresses
+	DefaultCMNPoolString = "10.103.6.128/25"
+	// DefaultCMNStaticString is the default pool for Static CMN addresses
+	DefaultCMNStaticString = "10.103.6.112/28"
+	// DefaultCMNVlan is the default CMN Bootstrap Vlan
+	DefaultCMNVlan = 6
 	// DefaultCANString is the Default CAN String (vlan007)
 	DefaultCANString = "10.102.11.0/24"
 	// DefaultCANPoolString is the default pool for CAN addresses
@@ -68,7 +76,7 @@ const (
 )
 
 // ValidNetNames is the list of strings that enumerate valid main network names
-var ValidNetNames = []string{"HMN", "NMN", "CAN", "MTL", "HMN_RVR", "HMN_MTN", "NMN_RVR", "NMN_MTN"}
+var ValidNetNames = []string{"HMN", "NMN", "CMN", "CAN", "MTL", "HMN_RVR", "HMN_MTN", "NMN_RVR", "NMN_MTN"}
 
 // ValidCabinetTypes is the list of strings that enumerate valid cabinet types
 var ValidCabinetTypes = []string{"mountain", "river", "hill"}
@@ -133,7 +141,7 @@ func GenDefaultHMN() IPV4Network {
 		FullName:  "Hardware Management Network",
 		CIDR:      DefaultHMNString,
 		Name:      "HMN",
-		VlanRange: []int16{100, 356},
+		VlanRange: []int16{DefaultHMNVlan},
 		MTU:       9000,
 		NetType:   "ethernet",
 		Comment:   "",
@@ -146,7 +154,7 @@ func GenDefaultNMN() IPV4Network {
 		FullName:  "Node Management Network",
 		CIDR:      DefaultNMNString,
 		Name:      "NMN",
-		VlanRange: []int16{357, 612},
+		VlanRange: []int16{DefaultNMNVlan},
 		MTU:       9000,
 		NetType:   "ethernet",
 		Comment:   "",
@@ -164,12 +172,23 @@ var DefaultHSN = IPV4Network{
 	Comment:   "",
 }
 
+// DefaultCMN is the default structure for templating initial CMN configuration
+var DefaultCMN = IPV4Network{
+	FullName:  "Customer Management Network",
+	CIDR:      DefaultCMNString,
+	Name:      "CMN",
+	VlanRange: []int16{DefaultCMNVlan},
+	MTU:       9000,
+	NetType:   "ethernet",
+	Comment:   "",
+}
+
 // DefaultCAN is the default structure for templating initial CAN configuration
 var DefaultCAN = IPV4Network{
 	FullName:  "Customer Access Network",
 	CIDR:      DefaultCANString,
 	Name:      "CAN",
-	VlanRange: []int16{11, 35},
+	VlanRange: []int16{DefaultCANVlan},
 	MTU:       9000,
 	NetType:   "ethernet",
 	Comment:   "",
@@ -180,7 +199,7 @@ var DefaultMTL = IPV4Network{
 	FullName:  "Provisioning Network (untagged)",
 	CIDR:      DefaultMTLString,
 	Name:      "MTL",
-	VlanRange: []int16{36, 40},
+	VlanRange: []int16{1},
 	MTU:       9000,
 	NetType:   "ethernet",
 	Comment:   "This network is only valid for the NCNs",
@@ -228,6 +247,20 @@ func GenDefaultHSNConfig() NetworkLayoutConfiguration {
 		IncludeBootstrapDHCP:            false,
 		IncludeNetworkingHardwareSubnet: false,
 		IncludeUAISubnet:                false,
+	}
+}
+
+// GenDefaultCMNConfig returns the set of defaults for mapping the CMN
+func GenDefaultCMNConfig() NetworkLayoutConfiguration {
+
+	return NetworkLayoutConfiguration{
+		Template:                        DefaultCMN,
+		SubdivideByCabinet:              false,
+		SuperNetHack:                    false,
+		IncludeBootstrapDHCP:            true,
+		IncludeNetworkingHardwareSubnet: false,
+		IncludeUAISubnet:                false,
+		DesiredBootstrapDHCPMask:        net.CIDRMask(24, 32),
 	}
 }
 

--- a/pkg/csi/logical_ncn.go
+++ b/pkg/csi/logical_ncn.go
@@ -30,6 +30,7 @@ type LogicalNCN struct {
 	NmnIP            string         `yaml:"nmn-ip" json:"nmn-ip" csv:"-"`
 	HmnIP            string         `yaml:"hmn-ip" json:"hmn-ip" csv:"-"`
 	MtlIP            string         `yaml:"mtl-ip" json:"mtl-ip" csv:"-"`
+	CmnIP            string         `yaml:"cmn-ip" json:"cmn-ip" csv:"-"`
 	CanIP            string         `yaml:"can-ip" json:"can-ip" csv:"-"`
 	Xname            string         `yaml:"xname" json:"xname" csv:"NCN xname"`
 	Hostname         string         `yaml:"hostname" json:"hostname" csv:"-"`

--- a/pkg/pit/networks.go
+++ b/pkg/pit/networks.go
@@ -17,13 +17,6 @@ import (
 	"github.com/Cray-HPE/cray-site-init/pkg/csi"
 )
 
-// WriteNetworkFiles persistes our network configuration to disk in a directory of yaml files
-func WriteNetworkFiles(basepath string, networks map[string]*csi.IPV4Network) {
-	for k, v := range networks {
-		csiFiles.WriteYAMLConfig(filepath.Join(basepath, fmt.Sprintf("networks/%v.yaml", k)), v)
-	}
-}
-
 // WriteCPTNetworkConfig writes the Network Configuration details for the installation node  (PIT)
 func WriteCPTNetworkConfig(path string, v *viper.Viper, ncn csi.LogicalNCN, shastaNetworks map[string]*csi.IPV4Network) error {
 	type Route struct {


### PR DESCRIPTION
### Summary and Scope

#### CMN
The CMN (Customer Management Network) will provide ingress administrative access to the system instead of the CAN as part of the CAN bifurcation process.  The CAN will remain in place, but be relegated to non-administrative (ie. regular user) traffic. This changes adds plumbing for the CMN. 

Default VLAN: 6
Default IPv4 Subnet: 10.103.6.0/24

New files:
```<hostname>/
        dnsmasq.d/
            CMN.conf
        pit-files/
            ifcfg-vlan006
```

New structure in sls_input_file.json:
```
        "CMN": {
            "Name": "CMN",
            "FullName": "Customer Management Network",
            "IPRanges": [
                "10.103.6.0/24"
            ],
            "Type": "ethernet",
            "ExtraProperties": {
                "CIDR": "10.103.6.0/24",
                "VlanRange": [
                    6
                ],
                "MTU": 9000,
                "Subnets": [
                    {
                        "FullName": "CMN Static Pool MetalLB",
                        "CIDR": "10.103.6.112/28",
                        "Name": "cmn_metallb_static_pool",
                        "VlanID": 6,
                        "Gateway": "10.103.6.113"
                    },
                    {
                        "FullName": "CMN Dynamic MetalLB",
                        "CIDR": "10.103.6.128/25",
                        "Name": "cmn_metallb_address_pool",
                        "VlanID": 6,
                        "Gateway": "10.103.6.129"
                    },
                    {
                        "FullName": "CMN Bootstrap DHCP Subnet",
                        "CIDR": "10.103.6.0/24",
                        "IPReservations": [...]
```

#### VLAN Handling
Previously VLANs from cli input were not consistently honored in the network VlanRanges or other structures.  This changeset also provides consistent defaults handling in structures, overrides via cli-input and output that has far less inconsistent and unused data.

VlanRange is now consistent with cli input and used subnet VLANs:
```
        "HMN": {
            "Name": "HMN",
            "FullName": "Hardware Management Network",
            "IPRanges": [
                "10.254.0.0/17"
            ],
            "Type": "ethernet",
            "ExtraProperties": {
                "CIDR": "10.254.0.0/17",
                "VlanRange": [
                    4
                ],
                "MTU": 9000,
                "Subnets": [...]
```


***OTHER***:
* Yaml output of network files has been removed.  Few people or scripts used this and those scripts are being changed.
* CLI network parameters that clash for CMN and CAN are now handled with appropriate error messaging (e.g. if CAN or CMN static/dynamic pools are not in the respective subnet a prescriptive error occurs.

### Issues and Related PRs

* Resolves CASMNET-690

### Testing

LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

* Generation and SLS load on Odin and Hela.
* Generation and SLS load on Surtur.


Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) **YES**  
Was a fresh Install tested? **YES**
Was an Upgrade tested?      **NO** - handled by another process.
Was a Downgrade tested?     **NO** 

### Risks and Mitigations

This is required for Bifurcated CAN in CSM 1.2.  Deployment earlier than this should not cause any impacts as the new structures will not be used by anything.
