### PR TITLE
Integrate test (MTL-1421 and MTL-1400)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 coverage*
 build/
+cmd/*/*

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,10 @@ test: build
 	gocover-cobertura < $(TEST_OUTPUT_DIR)/coverage.out > "$(TEST_OUTPUT_DIR)/coverage/coverage.xml"
 	go tool cover -html=$(TEST_OUTPUT_DIR)/coverage.out -o "$(TEST_OUTPUT_DIR)/coverage/coverage.html"
 
+# Run integration tests
+integrate:
+	go test ./cmd/... ./internal/... ./pkg/... -tags=integration -v -coverprofile coverage.out -covermode count
+
 vet: version
 	go vet -v ./...
 

--- a/cmd/cabinet_input_file_test.go
+++ b/cmd/cabinet_input_file_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
 Copyright 2021 Hewlett Packard Enterprise Development LP
 */
@@ -17,7 +19,7 @@ cabinets:
 - type: river
   cabinets:
     - id: 3000
- 
+
 - type: hill
   cabinets:
     - id: 9000

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,10 +5,7 @@ Copyright 2021 Hewlett Packard Enterprise Development LP
 package cmd
 
 import (
-	"errors"
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -17,44 +14,18 @@ import (
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{
-	Use:   "config [directory]",
-	Short: "Interact with a config in a named directory",
-	Long:  `Interact with a config in a named directory`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return errors.New("requires a named config directory")
-		}
-		info, err := os.Stat(args[0])
-		if err != nil {
-			return fmt.Errorf("could not read %v. %v", args[0], err)
-		}
-		if !info.Mode().IsDir() {
-			return fmt.Errorf("%v is not a directory", args[0])
-		}
-		return nil
-	},
+	Use:   "config",
+	Short: "Interact with a Shasta config",
+	Long:  `Interact with a Shasta config`,
+	Args:  cobra.MinimumNArgs(1),
 }
 
 func init() {
-	rootCmd.AddCommand(configCmd)
 	configCmd.DisableAutoGenTag = true
-}
-
-// LoadConfig : Search reasonable places and read the installer configuration file
-// Possibly no longer relevant
-func LoadConfig() {
-	// Read in the configfile
-	viper.SetConfigName("system_config")
-	viper.AddConfigPath(".")
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			log.Fatalln(fmt.Errorf("fatal error config file: %s", err))
-		}
-	}
-	viper.SetEnvPrefix("CSM")
-	viper.AutomaticEnv()
-	viper.WatchConfig()
+	configCmd.AddCommand(dumpCmd)
+	configCmd.AddCommand(genSLSCmd)
+	configCmd.AddCommand(initCmd)
+	configCmd.AddCommand(loadCmd)
 }
 
 // PrintConfig : Dump all configuration information as a yaml file on stdout

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -12,20 +12,18 @@ import (
 // dumpCmd represents the dump command
 var dumpCmd = &cobra.Command{
 	Use:   "dump",
-	Short: "",
+	Short: "Dumps an existing config to STDOUT",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		LoadConfig()
 		if len(args) < 1 {
 			PrintConfig(viper.GetViper())
 		} else {
 			subv := viper.Sub(args[0])
 			PrintConfig(subv)
-
 		}
 	},
 }
 
 func init() {
-	configCmd.AddCommand(dumpCmd)
 	dumpCmd.DisableAutoGenTag = true
 }

--- a/cmd/gen-sls.go
+++ b/cmd/gen-sls.go
@@ -32,11 +32,9 @@ var genSLSCmd = &cobra.Command{
 }
 
 func init() {
-	configCmd.AddCommand(genSLSCmd)
 	genSLSCmd.DisableAutoGenTag = true
 	genSLSCmd.Flags().Int16("river-cabinets", 1, "Number of River cabinets")
 	genSLSCmd.Flags().Int("hill-cabinets", 0, "Number of River cabinets")
-
 }
 
 func genCabinetMap(cd []csi.CabinetGroupDetail, shastaNetworks map[string]*csi.IPV4Network) map[string]map[string]sls_common.GenericHardware {

--- a/cmd/gen-sls_test.go
+++ b/cmd/gen-sls_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
 Copyright 2021 Hewlett Packard Enterprise Development LP
 */

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,0 +1,67 @@
+// +build integration
+
+package cmd
+
+/*
+Copyright 2021 Hewlett Packard Enterprise Development LP
+*/
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGet_ShastaSystemConfigs(t *testing.T) {
+
+	// These are the five input files needed (two are optional) for running 'csi config init'
+	configs := []string{"application_node_config.yaml",
+		"cabinets.yaml",
+		"hmn_connections.json",
+		"ncn_metadata.csv",
+		"switch_metadata.csv",
+		"system_config.yaml"}
+
+	var systems []string
+	var configURL, url string
+
+	// The sample data set of systems names to use
+	// For now, this should align with the system names in init_test.go
+	if os.Getenv("CSI_SHASTA_SYSTEMS") != "" {
+
+		systems = strings.Split(os.Getenv("CSI_SHASTA_SYSTEMS"), " ")
+
+	} else {
+
+		t.Errorf("CSI_SHASTA_SYSTEMS needs to be set")
+
+	}
+
+	for _, s := range systems {
+
+		// Make a directory to hold each set of configs
+		os.MkdirAll(filepath.Join(s), 0755)
+
+		for _, f := range configs {
+
+			configURL = os.Getenv("CSI_SHASTA_CONFIG_URL")
+
+			if configURL != "" {
+
+				url = configURL + s + "/" + f
+
+			} else {
+
+				t.Errorf("CSI_SHASTA_CONFIG_URL needs to be set")
+
+			}
+
+			// Download the file
+			output := GetArtifact(filepath.Join(s), url)
+
+			if output != nil {
+				t.Errorf("Expected no error, but got %s", output)
+			}
+		}
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,7 +29,7 @@ import (
 // initCmd represents the init command
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "init generates the directory structure for a new system rooted in a directory matching the system-name argument",
+	Short: "Generates a Shasta configuration payload",
 	Long: `init generates a scaffolding the Shasta configuration payload.  It is based on several input files:
 	1. The hmn_connections.json which describes the cabling for the BMCs on the NCNs
 	2. The ncn_metadata.csv file documents the MAC addresses of the NCNs to be used in this installation
@@ -58,22 +58,16 @@ var initCmd = &cobra.Command{
 		var err error
 		// Initialize the global viper
 		v := viper.GetViper()
-		v.SetConfigName("system_config")
-		v.AddConfigPath(".")
-		// Attempt to read the config file, gracefully ignoring errors
-		// caused by a config file not being found. Return an error
-		// if we cannot parse the config file.
-		if err := v.ReadInConfig(); err != nil {
-			// It's okay if there isn't a config file
-			if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-				log.Fatalln(err)
-			}
-		}
+
+		v.BindPFlags(cmd.Flags())
 
 		flagErrors := validateFlags()
 		if len(flagErrors) > 0 {
 			cmd.Usage()
-			log.Fatalf(strings.Join(flagErrors, "/n"))
+			for _, e := range flagErrors {
+				log.Println(e)
+			}
+			log.Fatal("One or more flags are invalid")
 		}
 
 		if len(strings.Split(v.GetString("site-ip"), "/")) != 2 {
@@ -305,7 +299,6 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	configCmd.AddCommand(initCmd)
 	initCmd.DisableAutoGenTag = true
 
 	// Flags with defaults for initializing a configuration
@@ -626,8 +619,8 @@ func validateFlags() []string {
 	v := viper.GetViper()
 	var requiredFlags = []string{
 		"system-name",
-		"cmn-gateway",
 		"can-gateway",
+		"cmn-gateway",
 		"site-ip",
 		"site-gw",
 		"can-external-dns",
@@ -639,7 +632,7 @@ func validateFlags() []string {
 
 	for _, flagName := range requiredFlags {
 		if !v.IsSet(flagName) {
-			errors = append(errors, fmt.Sprintf("%v is required and not set through flag or config file (.%s)", flagName, v.ConfigFileUsed()))
+			errors = append(errors, fmt.Sprintf("%v is required and not set through flag or config file (%s)", flagName, v.ConfigFileUsed()))
 		}
 	}
 

--- a/cmd/init_integration_test.go
+++ b/cmd/init_integration_test.go
@@ -1,0 +1,66 @@
+// +build integration
+
+/*
+Copyright 2021 Hewlett Packard Enterprise Development LP
+*/
+
+package cmd
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Cray-HPE/cray-site-init/pkg/csi"
+)
+
+// ConfigInitTest runs 'csi config init' on a system passed to it using the cobra command object
+func ConfigInitTest(system string) {
+
+	var cwd string
+
+	// pseudo-pushd: Move into the directory (this should have been created in get_test.go)
+	confdir, _ := filepath.Abs(system)
+	os.Chdir(filepath.Join(confdir))
+	cwd, _ = os.Getwd()
+	log.Printf("pushd  ===> %s", cwd)
+
+	// Runs 'config init' without any arguments (this requires system_config.yaml to be present in the dir)
+	// csi.ExecuteCommandC(rootCmd, []string{"config", "init"})
+	conf := confdir + "/system_config.yaml"
+	csi.ExecuteCommandC(rootCmd, []string{"--config", conf, "config", "init"})
+
+	// pseudo-popd
+	os.Chdir(filepath.Join(".."))
+	cwd, _ = os.Getwd()
+	log.Printf("popd  ===> %s", cwd)
+
+}
+
+func TestConfigInit_GeneratePayload(t *testing.T) {
+
+	var systems []string
+
+	// The sample data set of systems names to use
+	// For now, these should align with the system names in get_test.go
+	if os.Getenv("CSI_SHASTA_SYSTEMS") != "" {
+
+		systems = strings.Split(os.Getenv("CSI_SHASTA_SYSTEMS"), " ")
+
+	} else {
+
+		t.Errorf("CSI_SHASTA_SYSTEMS needs to be set")
+
+	}
+
+	for _, s := range systems {
+		// Run 'config init' on each system's set of seed files
+		// These files should have been previously gathered from get_test.go
+		ConfigInitTest(s)
+	}
+}
+
+// TODO: test 'config init' using command line flags instead of system_config.yaml
+// TODO: test--with some tolerance--that generated output is similiar to what we know is a good config

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
 Copyright 2021 Hewlett Packard Enterprise Development LP
 */

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -19,9 +19,9 @@ import (
 // loadCmd represents the load command
 var loadCmd = &cobra.Command{
 	Use:   "load <path>",
-	Short: "load a valid Shasta directory of configuration",
+	Short: "Load an existing Shasta configuration",
 	Long: `Load a set of files that represent a Shasta system.
-	Often load is used with init which generates the files.`,
+	Often, 'load' is used with 'init', which generates the files.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
 			log.Fatalln(errors.New("path needs to be provided"))
@@ -42,8 +42,8 @@ var loadCmd = &cobra.Command{
 }
 
 func init() {
-	configCmd.AddCommand(loadCmd)
 	loadCmd.DisableAutoGenTag = true
+
 }
 
 func loadSystemConfig(path string) (sysconf csi.SystemConfig, err error) {

--- a/cmd/manage_input_files.go
+++ b/cmd/manage_input_files.go
@@ -7,12 +7,12 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"github.com/Cray-HPE/cray-site-init/internal/files"
 	"github.com/Cray-HPE/cray-site-init/pkg/csi"
 	shcd_parser "github.com/Cray-HPE/hms-shcd-parser/pkg/shcd-parser"
 	"github.com/spf13/viper"
-	"path/filepath"
 )
 
 type cabinetDefinition struct {
@@ -55,7 +55,7 @@ func collectSwitches(v *viper.Viper) []*csi.ManagementSwitch {
 
 	switches, err := csi.ReadSwitchCSV(seedFileSwitchMetadata)
 	if err != nil {
-		log.Fatalln("Couldn't extract switches", err)
+		log.Fatalf("Couldn't extract switches, %v", err)
 	}
 
 	// Normalize the management switch data, before validation
@@ -100,7 +100,8 @@ func collectApplicationNodeConfig(v *viper.Viper) csi.SLSGeneratorApplicationNod
 func collectCabinets(v *viper.Viper) []csi.CabinetGroupDetail {
 	var cabDetailFile csi.CabinetDetailFile
 	if v.IsSet("cabinets-yaml") {
-		err := files.ReadYAMLConfig(v.GetString("cabinets-yaml"), &cabDetailFile)
+		seedFileCabinets := filepath.Dir(viper.ConfigFileUsed()) + "/" + v.GetString("cabinets-yaml")
+		err := files.ReadYAMLConfig(seedFileCabinets, &cabDetailFile)
 		if err != nil {
 			log.Fatalf("Unable to parse cabinets-yaml file: %s\nError: %v", v.GetString("cabinets-yaml"), err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,42 +5,53 @@ Copyright 2021 Hewlett Packard Enterprise Development LP
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/viper"
 )
-
-var cfgFile string
 
 const (
 	defaultConfigFilename = "csi"
 	envPrefix             = "csi"
 )
 
+var (
+	cfgFile string
+	cwd     string
+)
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "csi",
-	Short: "Cray Site Init. for new sites ore re-installs and upgrades.",
+	Short: "Cray Site Init. For new sites, re-installs, and upgrades.",
 	Long: `
-CSI creates, validates, installs, and upgrades a CRAY supercomputer or HPCaaS platform.
+	CSI creates, validates, installs, and upgrades a CRAY supercomputer or HPCaaS platform.
 
-It supports initializing a set of configuration from a variety of inputs including 
-flags (and/or Shasta 1.3 configuration files). It can also validate that a set of 
-configuration details are accurate before attempting to use them for installation.
+	It supports initializing a set of configuration files from a variety of inputs including
+	flags and Shasta 1.3 configuration files. It can also validate that a set of
+	configuration details are accurate before attempting to use them for installation.
 
-Configs aside, this will prepare USB sticks for deploying on baremetal or for recovery and
-triage.`,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		return initializeFlagswithViper(cmd)
-	},
+	Configs aside, this will prepare USB sticks for deploying on baremetal or for recovery and
+	triage.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// When we bind flags to environment variables expect that the
+		// environment variables are prefixed, e.g. a flag like --number
+		// binds to an environment variable STRING_NUMBER. This helps
+		// avoid conflicts.
+		reg, err := regexp.Compile("[^A-Za-z0-9]+")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// "csi config init --option" => csi_CONFIG_INIT_OPTION
+		reggie := reg.ReplaceAllString(cmd.CommandPath(), "_")
+		log.Println(reggie)
+		viper.BindPFlags(cmd.Flags())
 		cmd.Usage()
 	},
 }
@@ -49,73 +60,39 @@ triage.`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Println(err)
 		os.Exit(1)
 	}
 }
 
-// This function is useful for understanding what a particular viper contains.
-// It is more a crutch for development than anything I would ever expect a customer to see.
-func viperWiper(v *viper.Viper) {
-	fmt.Print("\n === Viper Wiper === \n\n")
-	for _, name := range v.AllKeys() {
-		fmt.Println("Key: ", name, " => Name:", v.GetString(name))
+func initConfig() {
+	if cfgFile != "" {
+		// Set the config file from the logic and checks above
+		cfgFile, _ = filepath.Abs(cfgFile)
+	} else {
+		// log.Println("Using default config location")
+		cfgFile = "system_config.yaml"
+		cfgFile, _ = filepath.Abs(cfgFile)
 	}
-	fmt.Print("\n === Viper Wiper Done === \n\n")
+
+	viper.SetConfigFile(cfgFile)
+
+	if err := viper.ReadInConfig(); err == nil {
+		log.Println("Using config file:", viper.ConfigFileUsed())
+	}
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 }
 
-// This function maps all pflags to strings in viper
-func initializeFlagswithViper(cmd *cobra.Command) error {
-	v := viper.GetViper()
+func init() {
+	// We don't actually use this until a user runs 'config init', but it's more
+	// standard to keep it here in the main file
+	cobra.OnInitialize(initConfig)
 
-	if cfgFile != "" {
-		// Use config file from the flag.
-		v.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			log.Fatalf("Home Directory not found: %v", err)
-		}
-		// Add the home directory to the config path
-		v.AddConfigPath(home)
+	rootCmd.AddCommand(configCmd)
 
-		// Add the local directory to the config path
-		v.AddConfigPath(".")
-		// Set the base name of the config file, without the file extension.
-		v.SetConfigName(defaultConfigFilename)
-	}
-
-	// Attempt to read the config file, gracefully ignoring errors
-	// caused by a config file not being found. Return an error
-	// if we cannot parse the config file.
-	if err := v.ReadInConfig(); err != nil {
-		// It's okay if there isn't a config file
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return err
-		}
-	}
-
-	// When we bind flags to environment variables expect that the
-	// environment variables are prefixed, e.g. a flag like --number
-	// binds to an environment variable STRING_NUMBER. This helps
-	// avoid conflicts.
-	reg, err := regexp.Compile("[^A-Za-z0-9]+")
-	if err != nil {
-		log.Fatal(err)
-	}
-	// "csi config init --option" => csi_CONFIG_INIT_OPTION
-	v.SetEnvPrefix(reg.ReplaceAllString(cmd.CommandPath(), "_"))
-
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
-	// Bind to environment variables
-	// Works great for simple config names, but needs help for names
-	// like --favorite-color which we fix in the bindFlags function
-	v.AutomaticEnv()
-
-	// Bind the current command's flags to viper
-	v.BindPFlags(cmd.Flags())
-
-	return nil
+	// Add a global '--config' option, so someone can pass in their own
+	// config file if desired, overriding the one in the current dir when
+	// we initialize this cobra program
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,6 +21,7 @@ var versionCmd = &cobra.Command{
 	Short: "version",
 	Run: func(cmd *cobra.Command, args []string) {
 		v := viper.GetViper()
+		v.BindPFlags(cmd.Flags())
 		clientVersion := version.Get()
 		if v.GetBool("simple") {
 			fmt.Printf("%v.%v\n", clientVersion.Major, clientVersion.Minor)

--- a/internal/files/common.go
+++ b/internal/files/common.go
@@ -9,30 +9,9 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/viper"
 )
-
-// ImportConfig converts a configuration file to a viper
-func ImportConfig(configfile string) (*viper.Viper, error) {
-	dirname, filename := path.Split(configfile)
-	extenstion := filepath.Ext(filename)
-	name := strings.TrimSuffix(filename, extenstion)
-
-	config := viper.New()
-	config.SetConfigType(strings.TrimPrefix(extenstion, "."))
-	config.SetConfigName(name)
-	config.AddConfigPath(dirname)
-	err := config.ReadInConfig()
-	if err != nil {
-		return config, err
-	}
-	config.WatchConfig()
-	return config, nil
-}
 
 // ExportConfig converts a viper to a file on disk
 func ExportConfig(configfile string, config *viper.Viper) error {

--- a/pkg/csi/cabinets_test.go
+++ b/pkg/csi/cabinets_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
 Copyright 2021 Hewlett Packard Enterprise Development LP
 */

--- a/pkg/csi/logical_ncn_test.go
+++ b/pkg/csi/logical_ncn_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
 Copyright 2021 Hewlett Packard Enterprise Development LP
 */

--- a/pkg/csi/sls-state-generator_test.go
+++ b/pkg/csi/sls-state-generator_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 // Copyright 2021 Hewlett Packard Enterprise Development LP
 
 package csi

--- a/pkg/csi/sls_test.go
+++ b/pkg/csi/sls_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
 Copyright 2021 Hewlett Packard Enterprise Development LP
 */

--- a/pkg/csi/switches_test.go
+++ b/pkg/csi/switches_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 /*
 Copyright 2021 Hewlett Packard Enterprise Development LP
 */

--- a/pkg/csi/util.go
+++ b/pkg/csi/util.go
@@ -4,6 +4,12 @@ Copyright 2021 Hewlett Packard Enterprise Development LP
 
 package csi
 
+import (
+	"bytes"
+
+	"github.com/spf13/cobra"
+)
+
 // stringInSlice is shorthand
 func stringInSlice(a string, list []string) bool {
 	for _, b := range list {
@@ -12,4 +18,16 @@ func stringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// ExecuteCommandC runs a cobra command
+func ExecuteCommandC(root *cobra.Command, args []string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+
+	c, err = root.ExecuteC()
+
+	return c, buf.String(), err
 }


### PR DESCRIPTION
Restores `make integrate` functionality to generate configs using `csi config init`.  Previously, #13  appeared to work, but resulted in `csi version` not displaying anything and the `config init` command sometimes not working.  I believe this was due to the cobra config flags not being bound to viper.  I have fixed this by adding `v.BindPFlags(cmd.Flags())` to the `init.go` and `version.go` so it is aware of the config being used.  There is also more error-checking on the config file being passed in.

This does change the way the config file is loaded to a more standard way described in the cobra docs.  We were loading our config in more than one place, and this aims to standardize it a bit more, while allowing the integration tests to still work.  