### PR TITLE
CASMINST-3272 bind flags for upload_sls command

### DIFF
--- a/cmd/upload-sls.go
+++ b/cmd/upload-sls.go
@@ -37,6 +37,7 @@ var uploadSLSFile = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Initialize the global viper
 		v := viper.GetViper()
+		v.BindPFlags(cmd.Flags())
 		uploadSLSInputFile(v)
 	},
 }


### PR DESCRIPTION
prior to MTL-1400 (#31), we had our own homegrown handling of config options and
flags.  In that PR, we aligned the codebase to resemble the examples in the
documentation.  This had the unfortunate side effect of mis-handling flags
passed to the program (as seen in #31).

As a specific example, the 'version' command would not produce output until we
fixed it with the exact same fix in this PR: https://github.com/Cray-HPE/cray-site-init/blob/8d3f82e7d5734e11c90d86173d7213b5ab8074cd/cmd/version.go#L24

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>