### PR TITLE
CASMTRIAGE-2440 fix pit populate pitdata -b not doing anything

### DIFF
--- a/cmd/pitdata.go
+++ b/cmd/pitdata.go
@@ -25,6 +25,7 @@ var pitdataCmd = &cobra.Command{
 	// Arg is the path to the csi generated files
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlags(cmd.Flags())
 		if viper.GetBool("basecamp") {
 			// Copies data.json to the configs folder
 			copyAllFiles(filepath.Join(args[0], "basecamp/"), filepath.Join(args[1]))


### PR DESCRIPTION
prior to MTL-1400 (#31), we had our own homegrown handling of config options and
flags.  In that PR, we aligned the codebase to resemble the examples in the
documentation.  This had the unfortunate side effect of mis-handling flags
passed to the program (as seen in #31).

As a specific example, the 'version' command would not produce output until we
fixed it with the exact same fix in this PR: https://github.com/Cray-HPE/cray-site-init/blob/8d3f82e7d5734e11c90d86173d7213b5ab8074cd/cmd/version.go#L24

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>