### PR TITLE
adjust integration test to use new required flag until system configs are updated

### DIFF
--- a/cmd/init_integration_test.go
+++ b/cmd/init_integration_test.go
@@ -31,7 +31,7 @@ func ConfigInitTest(system string) {
 	// Runs 'config init' without any arguments (this requires system_config.yaml to be present in the dir)
 	// csi.ExecuteCommandC(rootCmd, []string{"config", "init"})
 	conf := confdir + "/system_config.yaml"
-	csi.ExecuteCommandC(rootCmd, []string{"--config", conf, "config", "init"})
+	csi.ExecuteCommandC(rootCmd, []string{"--config", conf, "config", "init", "--cmn-gateway", "10.99.0.1"})
 
 	// pseudo-popd
 	os.Chdir(filepath.Join(".."))


### PR DESCRIPTION
This adds a stub value to the `make integrate` tests so it can complete without error.

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>