### PR TITLE
Revert "CASMTRIAGE-2403 change router to correct variable for HMN.conf dnsmasq config

### DIFF
--- a/pkg/pit/dnsmasq.go
+++ b/pkg/pit/dnsmasq.go
@@ -44,7 +44,7 @@ cname=registry.hmn,pit.hmn
 # This needs to point to the liveCD IP for provisioning in bare-metal environments.
 dhcp-option=interface:{{.VlanID | printf "vlan%03d"}},option:dns-server,{{.Gateway}}
 dhcp-option=interface:{{.VlanID | printf "vlan%03d"}},option:ntp-server,{{.Gateway}}
-dhcp-option=interface:{{.VlanID | printf "vlan%03d"}},option:router,{{.SupernetRouter}}
+dhcp-option=interface:{{.VlanID | printf "vlan%03d"}},option:router,{{.Gateway}}
 dhcp-range=interface:{{.VlanID | printf "vlan%03d"}},{{.DHCPStart}},{{.DHCPEnd}},10m
 `)
 


### PR DESCRIPTION
This reverts commit 2e9786bb2934b75644e7b3a01bae61a36c23acde.

