### PR TITLE
CASMTRIAGE-2522 remove unused cangw metadata

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,18 +12,17 @@
 - Docs Pull Request
 - RFE Pull Request
 
-words; describe what this change is and what it is for.
+<!--- words; describe what this change is and what it is for. -->
 
 #### Prerequisites
 
 - [ ] I have included documentation in my PR (or it is not required)
 - [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
  
-
 #### Idempotency
  
 <!--- describe testing done to verify code changes behave in an idempotent manner -->
  
 #### Risks and Mitigations
  
-What is less risky, or more risky now - or if your mod fails is there a new risk?
+<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->

--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -129,7 +129,6 @@ var cephWorkerRunCMD = []string{
 
 // Make sure any "FIXME" added to this is updated in the MakeBasecampGlobals function below
 var basecampGlobalString = `{
-	"can-gw": "~FIXME~ e.g. 10.102.9.20",
 	"ceph-cephfs-image": "dtr.dev.cray.com/cray/cray-cephfs-provisioner:0.1.0-nautilus-1.3",
 	"ceph-rbd-image": "dtr.dev.cray.com/cray/cray-rbd-provisioner:0.1.0-nautilus-1.3",
 	"docker-image-registry": "dtr.dev.cray.com",


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Requires https://github.com/Cray-HPE/node-image-build/pull/71
- Relates to CASMTRIAGE-2522 CASMINST-2120

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

Removes unused `can-gw` from metadata.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 

#### Idempotency
 
N/A <!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
This removed value will no longer need populating by hand, some metadata on older vintages of installs may contain this KVP. The KVP is now no longer used, so it is just extra data now in those older vintages.
