### PR TITLE
CASMPET-4885 Run join-spire-on-storage script

### DIFF
--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -101,6 +101,7 @@ var k8sRunCMD = []string{
 	"/srv/cray/scripts/common/update_ca_certs.py",
 	"/srv/cray/scripts/metal/install.sh",
 	"/srv/cray/scripts/common/kubernetes-cloudinit.sh",
+	"/srv/cray/scripts/join-spire-on-storage.sh",
 	"touch /etc/cloud/cloud-init.disabled",
 }
 


### PR DESCRIPTION
#### Summary and Scope

- Fixes [CASMPET-4885](https://connect.us.cray.com/jira/browse/CASMPET-4885)

##### Issue Type
- RFE Pull Request

This will attempt to join the storage nodes to spire the first time an
NCN is booted. It should fail until spire-server is running in the k8s
cluster. This is expected to succeed when ncn-m001 is rebooted. It will
not attempt to join nodes that already exist and contains a spire-server
healthcheck that times out after 5 minutes. This health check will fail
until sysmgmt is installed via loftsman.

#### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
Script has been run on internal systems manually. However, it has not been run this way before.

#### Idempotency
 
Ran the script multiple times. It checks to see if a storage node is already joined to spire and if so it doesn't attempt to do anything else with that node. If it's not joined then it will join the node.
 
#### Risks and Mitigations
 
If this script fails to work then cfs-status-reporter will not run properly on storage nodes. It has no affect on any other parts of the system.