### PR TITLE
MTL-1457 generate partially accurate ncn_metadata from shcd.json

### DIFF
--- a/cmd/shcd_integration_test.go
+++ b/cmd/shcd_integration_test.go
@@ -1,0 +1,218 @@
+// +build integration
+// +build shcd
+
+/*
+Copyright 2021 Hewlett Packard Enterprise Development LP
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/Cray-HPE/cray-site-init/pkg/csi"
+)
+
+// The user should populate this directory with the shcd.xlsx files for the systems they want to test
+const _testdataShcds = "../testdata/shcds/"
+
+var canus = []struct {
+	systemName string
+	version    string
+	tabs       string
+	corners    string
+	csmVersion string
+}{
+	{
+		systemName: "baldar",
+		version:    "V1",
+		tabs:       "25G_10G,NMN,HMN",
+		corners:    "I14,S65,J16,T23,J20,U46",
+		csmVersion: "1.0",
+	},
+	{
+		systemName: "drax",
+		version:    "V1",
+		tabs:       "HMN",
+		corners:    "J20,U36",
+		csmVersion: "1.0",
+	},
+	{
+		systemName: "ego",
+		version:    "V1",
+		tabs:       "NMN,HMN",
+		corners:    "I13,S18,J20,U36",
+		csmVersion: "1.0",
+	},
+	{
+		systemName: "fanta",
+		version:    "V1",
+		tabs:       "HMN",
+		corners:    "J20,U43",
+		csmVersion: "1.2",
+	},
+	{
+		systemName: "hela",
+		version:    "Full",
+		tabs:       "MTN,10G_25G_40G_100G,NMN,HMN",
+		corners:    "K15,U36,I37,T107,J15,T20,J20,U38",
+		csmVersion: "1.2",
+	},
+	{
+		systemName: "odin",
+		version:    "Full",
+		tabs:       "10G_25G_40G_100G,NMN,HMN,MTN_TDS",
+		corners:    "I37,T125,J15,T24,J20,U51,K15,U36",
+		csmVersion: "1.2",
+	},
+	{
+		systemName: "redbull",
+		version:    "V1",
+		tabs:       "HMN",
+		corners:    "J20,U31",
+		csmVersion: "1.2",
+	},
+	// {
+	// 	systemName: "rocket",
+	// 	version:    "V1",
+	// 	tabs:       "40G_10G,NMN,HMN",
+	// 	corners:    "I12,T38,I9,S24,J20,V36",
+	//  csmVersion: "1.0",
+	// },
+	{
+		systemName: "thanos",
+		version:    "V1",
+		tabs:       "HMN",
+		corners:    "J20,U36",
+		csmVersion: "1.0",
+	},
+	{
+		systemName: "sif",
+		version:    "V1",
+		tabs:       "HMN",
+		corners:    "J20,U35",
+		csmVersion: "1.0",
+	},
+}
+
+// CanuCommand runs arbitrary canu commands
+func CanuCommand(args ...string) {
+	// run canu
+	cmd := exec.Command("canu", args...)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+
+	err := cmd.Run()
+	if err != nil {
+		log.Fatalf("cmd.Run() failed with %s\n", err)
+	}
+}
+
+// WalkShcds walks the testdata/shcds directory and checks for shcd.xlsx files matching a regex of the system name
+func WalkShcds(root string, re *regexp.Regexp) ([]string, error) {
+	var files []string
+	// walk the testdata/shcds directory and look for any .xlsx files that match the system name
+	// these will be used to generate an shcd.json, which will then be used in the subsequent tests
+	err := filepath.Walk(_testdataShcds, func(path string, info os.FileInfo, err error) error {
+
+		// if it not a directory and it is an excel file and it matches the regex
+		if !info.IsDir() && filepath.Ext(path) == ".xlsx" && re.MatchString(path) {
+			// add the file to the list of shcd files that will be used
+			files = append(files, path)
+		}
+		return err
+	})
+
+	if err != nil {
+		return files, err
+	}
+
+	return files, err
+}
+
+// TestConfigureShcds runs canu validate against the shcd.xlsx and then generates csi seed files
+func TestConfigShcd_GenerateSeeds(t *testing.T) {
+
+	var systemDir string
+	var shcds []string
+
+	// for each test case
+	for _, test := range canus {
+
+		// make a dir to hold the generated configs
+		systemDir = filepath.Join(_testdataShcds, test.systemName)
+		os.Mkdir(systemDir, 0755)
+
+		// case-insensitive regex to use for matching system names to the filenames
+		fnameRegex := "(?i)(.*)(" + test.systemName + ")(.*)"
+		re := regexp.MustCompile(fnameRegex)
+
+		// walk the testdata/shcds directory and look for any .xlsx files that match the system name
+		files, err := WalkShcds(_testdataShcds, re)
+
+		for f := range files {
+			shcds = append(shcds, files[f])
+		}
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// For each file found in the testdata/shcds directory
+	for s := range shcds {
+		// Start a loop of all the test cases to see if we can find a matching system name
+		for _, test := range canus {
+
+			// case-insensitive regex to use for matching system names to the filenames
+			fnameRegex := "(?i)(.*)(" + test.systemName + ")(.*)"
+			re := regexp.MustCompile(fnameRegex)
+
+			// If there is a match, run 'canu' and 'csi config shcd'
+			if re.MatchString(shcds[s]) {
+				// Get the mac addresses from the leaf switch of the system
+				log.Println("Running canu for " + test.systemName + "...")
+
+				// Run canu against the shcd.xlsx file to generate the shcd.json
+				CanuCommand("validate",
+					"shcd",
+					"-a", test.version,
+					"--shcd", shcds[s],
+					"--tabs", test.tabs,
+					"--corners", test.corners,
+					"--json",
+					"--out", filepath.Join(_testdataShcds, test.systemName, test.systemName+".json"))
+
+				// Generate the seed files from the newly-crafted shcd.json
+				csi.ExecuteCommandC(rootCmd, []string{"config", "shcd",
+					filepath.Join(_testdataShcds, test.systemName, test.systemName+".json"),
+					"-SHAN",
+					"-j", _schemaFile})
+
+				// Move the files into the folder for the system so everything is together at the end of the test
+				filesToMove := []string{hmn_connections, switch_metadata, application_node_config, ncn_metadata}
+
+				for _, f := range filesToMove {
+					err := os.Rename(f, filepath.Join(_testdataShcds, test.systemName, f))
+
+					if err != nil {
+						log.Fatal(err)
+					}
+
+				}
+				break
+			} else {
+				continue
+			}
+		}
+	}
+}

--- a/testdata/expected/application_node_config.yaml
+++ b/testdata/expected/application_node_config.yaml
@@ -1,0 +1,18 @@
+---
+# Additional application node prefixes to match in the hmn_connections.json file
+prefixes:
+  - lnet
+
+# Additional HSM SubRoles
+prefix_hsm_subroles:
+  lnet: LNETRouter
+
+# Application Node aliases
+aliases:
+  x3000c0s17b0n0: ["uan001"]
+  x3000c0s18b0n0: ["uan002"]
+  x3000c0s19b0n0: ["uan003"]
+  x3000c0s21b0n0: ["uan004"]
+  x3000c0s25b0n0: ["uan006"]
+  x3000c0s27b0n0: ["lnet01"]
+  x3000c0s29b0n0: ["uan000"]

--- a/testdata/expected/hmn_connections.json
+++ b/testdata/expected/hmn_connections.json
@@ -1,0 +1,418 @@
+[
+  {
+   "Source": "sw-cdu-002",
+   "SourceRack": "x1000",
+   "SourceLocation": "u42",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u41",
+   "DestinationPort": "j52"
+  },
+  {
+   "Source": "sw-spine-002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u38",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u37",
+   "DestinationPort": "j32"
+  },
+  {
+   "Source": "sw-spine-001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u37",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u38",
+   "DestinationPort": "j32"
+  },
+  {
+   "Source": "sw-cdu-001",
+   "SourceRack": "x1000",
+   "SourceLocation": "u41",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j52"
+  },
+  {
+   "Source": "sw-leaf-004",
+   "SourceRack": "x3000",
+   "SourceLocation": "u36",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u35",
+   "DestinationPort": "j56"
+  },
+  {
+   "Source": "sw-leaf-003",
+   "SourceRack": "x3000",
+   "SourceLocation": "u35",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j56"
+  },
+  {
+   "Source": "sw-leaf-002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u34",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u33",
+   "DestinationPort": "j56"
+  },
+  {
+   "Source": "sw-leaf-001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u33",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j56"
+  },
+  {
+   "Source": "sw-leaf-bmc-002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u32",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j48"
+  },
+  {
+   "Source": "sw-leaf-bmc-001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u31",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j48"
+  },
+  {
+   "Source": "lnet01",
+   "SourceRack": "x3000",
+   "SourceLocation": "u27",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j9"
+  },
+  {
+   "Source": "uan006",
+   "SourceRack": "x3000",
+   "SourceLocation": "u25",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j19"
+  },
+  {
+   "Source": "uan004",
+   "SourceRack": "x3000",
+   "SourceLocation": "u21",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j17"
+  },
+  {
+   "Source": "uan003",
+   "SourceRack": "x3000",
+   "SourceLocation": "u19",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j16"
+  },
+  {
+   "Source": "uan002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u18",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j15"
+  },
+  {
+   "Source": "uan001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u17",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j14"
+  },
+  {
+   "Source": "ncn-s003",
+   "SourceRack": "x3000",
+   "SourceLocation": "u12",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j8"
+  },
+  {
+   "Source": "ncn-s002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u11",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j6"
+  },
+  {
+   "Source": "ncn-s001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u10",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j5"
+  },
+  {
+   "Source": "ncn-w006",
+   "SourceRack": "x3000",
+   "SourceLocation": "u09",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j4"
+  },
+  {
+   "Source": "ncn-w005",
+   "SourceRack": "x3000",
+   "SourceLocation": "u08",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j3"
+  },
+  {
+   "Source": "ncn-w004",
+   "SourceRack": "x3000",
+   "SourceLocation": "u07",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j2"
+  },
+  {
+   "Source": "ncn-w003",
+   "SourceRack": "x3000",
+   "SourceLocation": "u06",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j5"
+  },
+  {
+   "Source": "ncn-w002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u05",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j4"
+  },
+  {
+   "Source": "ncn-w001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u04",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j3"
+  },
+  {
+   "Source": "ncn-m003",
+   "SourceRack": "x3000",
+   "SourceLocation": "u03",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u36",
+   "DestinationPort": "j1"
+  },
+  {
+   "Source": "ncn-m002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u02",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j2"
+  },
+  {
+   "Source": "ncn-m001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u01",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u34",
+   "DestinationPort": "j1"
+  },
+  {
+   "Source": "cn008",
+   "SourceRack": "x3000",
+   "SourceLocation": "u15L",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u31",
+   "DestinationPort": "j8"
+  },
+  {
+   "Source": "cn007",
+   "SourceRack": "x3000",
+   "SourceLocation": "u16L",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u31",
+   "DestinationPort": "j7"
+  },
+  {
+   "Source": "cn006",
+   "SourceRack": "x3000",
+   "SourceLocation": "u16R",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u31",
+   "DestinationPort": "j6"
+  },
+  {
+   "Source": "cn005",
+   "SourceRack": "x3000",
+   "SourceLocation": "u15R",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u31",
+   "DestinationPort": "j5"
+  },
+  {
+   "Source": "cn004",
+   "SourceRack": "x3000",
+   "SourceLocation": "u13L",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u32",
+   "DestinationPort": "j28"
+  },
+  {
+   "Source": "cn003",
+   "SourceRack": "x3000",
+   "SourceLocation": "u14L",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u32",
+   "DestinationPort": "j27"
+  },
+  {
+   "Source": "cn002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u13R",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u32",
+   "DestinationPort": "j26"
+  },
+  {
+   "Source": "cn001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u14R",
+   "SourceParent": "FIXME INSERT SUBRACK HERE",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u32",
+   "DestinationPort": "j25"
+  },
+  {
+   "Source": "pdu-001",
+   "SourceRack": "x3000",
+   "SourceLocation": "p1",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u32",
+   "DestinationPort": "j48"
+  },
+  {
+   "Source": "pdu-000",
+   "SourceRack": "x3000",
+   "SourceLocation": "p0",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u31",
+   "DestinationPort": "j48"
+  },
+  {
+   "Source": "sw-hsn-002",
+   "SourceRack": "x3000",
+   "SourceLocation": "u40",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u32",
+   "DestinationPort": "j47"
+  },
+  {
+   "Source": "sw-hsn-001",
+   "SourceRack": "x3000",
+   "SourceLocation": "u39",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u31",
+   "DestinationPort": "j47"
+  },
+  {
+   "Source": "uan000",
+   "SourceRack": "x3000",
+   "SourceLocation": "u29",
+   "DestinationRack": "x3000",
+   "DestinationLocation": "u32",
+   "DestinationPort": "j43"
+  },
+  {
+   "Source": "cmm-x1000-000",
+   "SourceRack": "x1000",
+   "SourceLocation": "c0",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j1"
+  },
+  {
+   "Source": "cmm-x1000-001",
+   "SourceRack": "x1000",
+   "SourceLocation": "c1",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j2"
+  },
+  {
+   "Source": "cmm-x1000-002",
+   "SourceRack": "x1000",
+   "SourceLocation": "c2",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j3"
+  },
+  {
+   "Source": "cmm-x1000-003",
+   "SourceRack": "x1000",
+   "SourceLocation": "c3",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j4"
+  },
+  {
+   "Source": "cmm-x1000-004",
+   "SourceRack": "x1000",
+   "SourceLocation": "c4",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j5"
+  },
+  {
+   "Source": "cmm-x1000-005",
+   "SourceRack": "x1000",
+   "SourceLocation": "c5",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j6"
+  },
+  {
+   "Source": "cmm-x1000-006",
+   "SourceRack": "x1000",
+   "SourceLocation": "c6",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j7"
+  },
+  {
+   "Source": "cmm-x1000-007",
+   "SourceRack": "x1000",
+   "SourceLocation": "c7",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j8"
+  },
+  {
+   "Source": "cec-x1000-000",
+   "SourceRack": "x1000",
+   "SourceLocation": "c6",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u41",
+   "DestinationPort": "j48"
+  },
+  {
+   "Source": "cec-x1000-001",
+   "SourceRack": "x1000",
+   "SourceLocation": "c7",
+   "DestinationRack": "x1000",
+   "DestinationLocation": "u42",
+   "DestinationPort": "j48"
+  }
+ ]

--- a/testdata/expected/ncn_metadata.csv
+++ b/testdata/expected/ncn_metadata.csv
@@ -1,0 +1,13 @@
+Xname,Role,Subrole,BMC MAC,Bootstrap MAC,Bond0 MAC0,Bond0 MAC1
+x3000c0s10b0n0,Management,Storage,MAC1,MAC2,MAC3,MAC4
+x3000c0s11b0n0,Management,Storage,MAC1,MAC2,MAC3,MAC4
+x3000c0s12b0n0,Management,Storage,MAC1,MAC2,MAC3,MAC4
+x3000c0s1b0n0,Management,Master,MAC1,MAC2,MAC3,MAC4
+x3000c0s2b0n0,Management,Master,MAC1,MAC2,MAC3,MAC4
+x3000c0s3b0n0,Management,Master,MAC1,MAC2,MAC3,MAC4
+x3000c0s4b0n0,Management,Worker,MAC1,MAC2,MAC3,MAC4
+x3000c0s5b0n0,Management,Worker,MAC1,MAC2,MAC3,MAC4
+x3000c0s6b0n0,Management,Worker,MAC1,MAC2,MAC3,MAC4
+x3000c0s7b0n0,Management,Worker,MAC1,MAC2,MAC3,MAC4
+x3000c0s8b0n0,Management,Worker,MAC1,MAC2,MAC3,MAC4
+x3000c0s9b0n0,Management,Worker,MAC1,MAC2,MAC3,MAC4

--- a/testdata/expected/switch_metadata.csv
+++ b/testdata/expected/switch_metadata.csv
@@ -1,0 +1,11 @@
+Switch Xname,Type,Brand
+d0w1,CDU,Aruba
+d0w2,CDU,Aruba
+x3000c0h33s1,Aggregation,Aruba
+x3000c0h34s1,Aggregation,Aruba
+x3000c0h35s1,Aggregation,Aruba
+x3000c0h36s1,Aggregation,Aruba
+x3000c0h37s1,Spine,Aruba
+x3000c0h38s1,Spine,Aruba
+x3000c0w31,Leaf,Aruba
+x3000c0w32,Leaf,Aruba


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

#### Summary and Scope

- Partially implements MTL-1457

##### Issue Type

- RFE Pull Request

Generates an `ncn_metadata.csv` file _with_ xnames, but _without_ MAC addresses (MACs are coming in a subsequent PR)

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Low.
