### PR TITLE
Remove api gw and variations from HMNLB

### DIFF
--- a/cmd/automation-ncn-preflight.go
+++ b/cmd/automation-ncn-preflight.go
@@ -44,7 +44,7 @@ var automateNCNPreflight = &cobra.Command{
 			}
 
 			fmt.Print(strings.Join(standardizeHostnames, ","))
-		} else{
+		} else {
 			log.Fatalf("Invalid action: %s!\n", action)
 		}
 	},

--- a/pkg/csi/networkBuilder.go
+++ b/pkg/csi/networkBuilder.go
@@ -87,25 +87,11 @@ func BuildCSMNetworks(internalNetConfigs map[string]NetworkLayoutConfiguration, 
 	pool, _ = tempHMNLoadBalancer.AddSubnet(net.CIDRMask(24, 32), "hmn_metallb_address_pool", int16(v.GetInt("hmn-bootstrap-vlan")))
 	pool.FullName = "HMN MetalLB"
 	for nme, rsrv := range PinnedMetalLBReservations {
-		// Because of the hack to pin ip addresses, we've got an overloaded datastructure in defaults.
-		// We need to prune it here before we write it out.  It's pretty ugly, but we plan to throw all of this code away when ip pinning is no longer necessary
-		if nme == "istio-ingressgateway" {
-			var hmnAliases []string
-			for _, alias := range rsrv.Aliases {
-				if !strings.HasSuffix(alias, ".local") {
-					if !stringInSlice(alias, []string{"packages", "registry", "spire", "api-gw", "api_gw"}) {
-						hmnAliases = append(hmnAliases, alias)
-
-					}
-				}
-			}
-			pool.AddReservationWithPin(nme, strings.Join(hmnAliases, ","), rsrv.IPByte)
-
-		} else {
-
+		// // Because of the hack to pin ip addresses, we've got an overloaded datastructure in defaults.
+		// // We need to prune it here before we write it out.  It's pretty ugly, but we plan to throw all of this code away when ip pinning is no longer necessary
+		if nme != "istio-ingressgateway" && nme != "istio-ingressgateway-local" {
 			pool.AddReservationWithPin(nme, strings.Join(rsrv.Aliases, ","), rsrv.IPByte)
 		}
-
 	}
 	networkMap["HMNLB"] = &tempHMNLoadBalancer
 


### PR DESCRIPTION
#### Summary and Scope
- Fixes CASMINST-2541

##### Issue Type
- Bugfix Pull Request https://github.com/Cray-HPE/cray-site-init/pull/94

A change (bf84bdf23671fc12d880f87ed62effcb2008d778) several months ago filtered out spire and api_gw values from the istioingressgateway list in an effort to both deprecate underscores in names as well as prevent both the HMN and NMN gateways from showing up in DNS, creating a bad pseudo DNS Round-Robin lookup which (will always) fail on HMN.  The previous change looked for "api_gw" and the compare function required an exact name (like "api_gw_service") so the name was not filtered properly from the list.

This change fully removes the "underscore" gateway values, but brings in CSM 1.2 requirements the the HMNLB not have any istio ingress gateway records.

Previously removed records (bf84bdf23671fc12d880f87ed62effcb2008d778):
* packages
* registry
* spire.local
* registry.local 
* packages.local
* spire
* packages

Records removed by current change:
* api-gw-service 
* api_gw_service

Previous change:
```
        "HMNLB": {
            "Name": "HMNLB",
            "FullName": "Hardware Management Network LoadBalancers",
            "IPRanges": [
                "10.94.100.0/24"
            ],
            "Type": "ethernet",
            "ExtraProperties": {
                "CIDR": "10.94.100.0/24",
                "VlanRange": null,
                "MTU": 9000,
                "Subnets": [
                    {
                        "FullName": "HMN MetalLB",
                        "CIDR": "10.94.100.0/24",
                        "IPReservations": [
                            {
                                "Name": "istio-ingressgateway",
                                "IPAddress": "10.94.100.71",
                                "Aliases": [
                                    "api-gw-service",
                                    "api_gw_service"
                                ],
                                "Comment": "api-gw-service,api_gw_service"
                            },
                            {
                                "Name": "istio-ingressgateway-local",
                                "IPAddress": "10.94.100.81",
                                "Aliases": [
                                    "api-gw-service.local"
                                ],
                                "Comment": "api-gw-service.local"
                            },
                            {
                                "Name": "rsyslog-aggregator",
                                "IPAddress": "10.94.100.72",
                                "Aliases": [
                                    "rsyslog-agg-service"
                                ],
                                "Comment": "rsyslog-agg-service"
                            },
                            {
                                "Name": "cray-tftp",
                                "IPAddress": "10.94.100.60",
                                "Aliases": [
                                    "tftp-service"
                                ],
                                "Comment": "tftp-service"
                            },
                            {
                                "Name": "unbound",
                                "IPAddress": "10.94.100.225",
                                "Aliases": [
                                    "unbound"
                                ],
                                "Comment": "unbound"
                            },
                            {
                                "Name": "docker-registry",
                                "IPAddress": "10.94.100.73",
                                "Aliases": [
                                    "docker_registry_service"
                                ],
                                "Comment": "docker_registry_service"
                            }
                        ],
                        "Name": "hmn_metallb_address_pool",
                        "VlanID": 4,
                        "Gateway": "10.94.100.1"
                    }
                ]
            }
        },
```

This change set:
```
        "HMNLB": {
            "Name": "HMNLB",
            "FullName": "Hardware Management Network LoadBalancers",
            "IPRanges": [
                "10.94.100.0/24"
            ],
            "Type": "ethernet",
            "ExtraProperties": {
                "CIDR": "10.94.100.0/24",
                "VlanRange": null,
                "MTU": 9000,
                "Subnets": [
                    {
                        "FullName": "HMN MetalLB",
                        "CIDR": "10.94.100.0/24",
                        "IPReservations": [
                            {
                                "Name": "cray-tftp",
                                "IPAddress": "10.94.100.60",
                                "Aliases": [
                                    "tftp-service"
                                ],
                                "Comment": "tftp-service"
                            },
                            {
                                "Name": "unbound",
                                "IPAddress": "10.94.100.225",
                                "Aliases": [
                                    "unbound"
                                ],
                                "Comment": "unbound"
                            },
                            {
                                "Name": "docker-registry",
                                "IPAddress": "10.94.100.73",
                                "Aliases": [
                                    "docker_registry_service"
                                ],
                                "Comment": "docker_registry_service"
                            },
                            {
                                "Name": "rsyslog-aggregator",
                                "IPAddress": "10.94.100.72",
                                "Aliases": [
                                    "rsyslog-agg-service"
                                ],
                                "Comment": "rsyslog-agg-service"
                            }
                        ],
                        "Name": "hmn_metallb_address_pool",
                        "VlanID": 4,
                        "Gateway": "10.94.100.1"
                    }
                ]
            }
        },
```

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ \x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 The underlying structure is static so cannot be user-modified.
 
#### Risks and Mitigations
 This is for a CSM 1.2 release where the API gateways have been split for bifurcated CAN.  For CSM 1.2 use the NMN.  Should this changeset be run on a pre-CSM 1.2 system, there will likely be some services that become inaccessible.
