### PR TITLE
Fix Signed RPM Builds Dying on ClamAV Permission Denied Errors

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,5 +1,6 @@
 @Library('csm-shared-library') _
 
+def promotionToken = ~"(master|main|release\\/.*)"
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
 pipeline {
   agent {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -51,4 +51,10 @@ pipeline {
       }
     }
   }
+  post {
+    always {
+      // Own files so jenkins can clean them up later
+      postChownFiles()
+    }
+  }
 }


### PR DESCRIPTION
Builds of signed RPMs have been broken since the 24th of November this year. This PR fixes that by adjusting the Jenkinsfile to accommodate whatever change lead to the permission/ownership problem blocking the ClamAV scan.

![image](https://user-images.githubusercontent.com/7772179/144074569-dd3e358b-80c3-4c72-9bd3-f4395acfc667.png)

Errors observed from `main` and git-tags since the 24th:
```bash
+ bash -c '/usr/bin/scan_clamav.sh | tee /tmp/scan_dir/clamavscan-1.log'
tee: /tmp/scan_dir/clamavscan-1.log: Permission denied
```