### PR TITLE
CASMNET-1165 and CASMINST-3670 Edge router cleanup and required CHN/CAN toggle

### DIFF
--- a/cmd/gen-sls.go
+++ b/cmd/gen-sls.go
@@ -1,6 +1,25 @@
-/*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/
+//
+//  MIT License
+//
+//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
 
 package cmd
 

--- a/cmd/gen-sls.go
+++ b/cmd/gen-sls.go
@@ -228,11 +228,6 @@ func convertIPV4NetworkToSLS(n *csi.IPV4Network) sls_common.Network {
 		subnets[i] = convertIPV4SubnetToSLS(subnet)
 	}
 
-	route := ""
-	if n.Name == "BICAN" {
-		route = csi.DefaultBICANNetwork
-	}
-
 	return sls_common.Network{
 		Name:     n.Name,
 		FullName: n.FullName,
@@ -246,7 +241,7 @@ func convertIPV4NetworkToSLS(n *csi.IPV4Network) sls_common.Network {
 			PeerASN:            n.PeerASN,
 			MyASN:              n.MyASN,
 			Subnets:            subnets,
-			SystemDefaultRoute: route,
+			SystemDefaultRoute: n.SystemDefaultRoute,
 		},
 	}
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -24,7 +24,6 @@
 // +build !integration
 // +build !shcd
 
-
 package cmd
 
 import (

--- a/pkg/csi/defaults.go
+++ b/pkg/csi/defaults.go
@@ -93,8 +93,6 @@ const (
 	DefaultCHNVlan = 5
 	// DefaultMTLString is the Default MTL String (bond0 interface)
 	DefaultMTLString = "10.1.1.0/16"
-	// DefaultBICANNetwork is the Network is where the system default route points at install
-	DefaultBICANNetwork = "CMN"
 )
 
 // DefaultApplicationNodePrefixes is the list of default Application node prefixes, for source column in the hmn_connections.json
@@ -202,13 +200,14 @@ func GenDefaultNMN() IPV4Network {
 
 // DefaultBICAN is the default structure for templating the initial BICAN toggle - CMN
 var DefaultBICAN = IPV4Network{
-	FullName:  "SystemDefaultRoute points the network name of the default route",
-	CIDR:      "0.0.0.0/0",
-	Name:      "BICAN",
-	VlanRange: []int16{0},
-	MTU:       9000,
-	NetType:   "ethernet",
-	Comment:   "",
+	FullName:           "SystemDefaultRoute points the network name of the default route",
+	CIDR:               "0.0.0.0/0",
+	Name:               "BICAN",
+	VlanRange:          []int16{0},
+	MTU:                9000,
+	NetType:            "ethernet",
+	Comment:            "",
+	SystemDefaultRoute: "",
 }
 
 // DefaultHSN is the default structure for templating initial HSN configuration
@@ -267,8 +266,9 @@ var DefaultMTL = IPV4Network{
 }
 
 // GenDefaultBICANConfig returns the set of defaults for mapping the BICAN toggle
-func GenDefaultBICANConfig() NetworkLayoutConfiguration {
+func GenDefaultBICANConfig(systemDefaultRoute string) NetworkLayoutConfiguration {
 
+	DefaultBICAN.SystemDefaultRoute = systemDefaultRoute
 	return NetworkLayoutConfiguration{
 		Template:                        DefaultBICAN,
 		SubdivideByCabinet:              false,

--- a/pkg/csi/network.go
+++ b/pkg/csi/network.go
@@ -36,16 +36,17 @@ import (
 
 // IPV4Network is a type for managing IPv4 Networks
 type IPV4Network struct {
-	FullName  string                 `yaml:"full_name"`
-	CIDR      string                 `yaml:"cidr"`
-	Subnets   []*IPV4Subnet          `yaml:"subnets"`
-	Name      string                 `yaml:"name"`
-	VlanRange []int16                `yaml:"vlan_range"`
-	MTU       int16                  `yaml:"mtu"`
-	NetType   sls_common.NetworkType `yaml:"type"`
-	Comment   string                 `yaml:"comment"`
-	PeerASN   int                    `yaml:"peer-asn"`
-	MyASN     int                    `yaml:"my-asn"`
+	FullName           string                 `yaml:"full_name"`
+	CIDR               string                 `yaml:"cidr"`
+	Subnets            []*IPV4Subnet          `yaml:"subnets"`
+	Name               string                 `yaml:"name"`
+	VlanRange          []int16                `yaml:"vlan_range"`
+	MTU                int16                  `yaml:"mtu"`
+	NetType            sls_common.NetworkType `yaml:"type"`
+	Comment            string                 `yaml:"comment"`
+	PeerASN            int                    `yaml:"peer-asn"`
+	MyASN              int                    `yaml:"my-asn"`
+	SystemDefaultRoute string                 `yaml:"system_default_route"`
 }
 
 // IPV4Subnet is a type for managing IPv4 Subnets

--- a/pkg/pit/dnsmasq.go
+++ b/pkg/pit/dnsmasq.go
@@ -1,6 +1,25 @@
-/*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/
+//
+//  MIT License
+//
+//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
 
 package pit
 

--- a/pkg/pit/dnsmasq.go
+++ b/pkg/pit/dnsmasq.go
@@ -184,15 +184,18 @@ func WriteDNSMasqConfig(path string, v *viper.Viper, bootstrap []csi.LogicalNCN,
 
 	// Shasta Networks:
 	netCMN, _ := template.New("cmnconfig").Parse(string(CMNConfigTemplate))
-	netCAN, _ := template.New("canconfig").Parse(string(CANConfigTemplate))
 	netHMN, _ := template.New("hmnconfig").Parse(string(HMNConfigTemplate))
 	netNMN, _ := template.New("nmnconfig").Parse(string(NMNConfigTemplate))
 	netMTL, _ := template.New("mtlconfig").Parse(string(MTLConfigTemplate))
 	writeConfig("CMN", path, *netCMN, networks)
-	writeConfig("CAN", path, *netCAN, networks)
 	writeConfig("HMN", path, *netHMN, networks)
 	writeConfig("NMN", path, *netNMN, networks)
 	writeConfig("MTL", path, *netMTL, networks)
+	// Work some BICAN required magic
+	if v.GetString("bican-user-network-name") == "CAN" || v.GetBool("retain-unused-user-network") {
+		netCAN, _ := template.New("canconfig").Parse(string(CANConfigTemplate))
+		writeConfig("CAN", path, *netCAN, networks)
+	}
 
 	// Expected NCNs (and other devices) reserved DHCP leases:
 	netIPAM, _ := template.New("statics").Parse(string(StaticConfigTemplate))


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMINST-3670
- Fixes CASMNET-1165

Previously CSI hard coded the BICAN toggle to "CMN" thinking that other tools would toggle live.  This change **requires** the user to pick a BICAN network via the new `bican-user-network-name` flag.  Once enabled the "other possible user network" will not be created by default.  For instance, if the user selects the CAN for BICAN, then the CHN will not be created.  This flag has the same behavior and same naming as the one used in the CSM 1.0 to 1.2 SLS upgrade script.

To allow more flexibility for pure development and testing and maintain parity with behavior in the SLS upgrade script, this change also adds the `retain-unused-user-network` flag.  By default his flag is off.  If enabled, it will preserve "the other user network".  For example if the user picks CHN and has the retention toggle enabled, both the CHN and the CAN will be retained.

Additional:
* (CASMNET-1165) Removed the dependence of MetalLB yaml generation on the Xname contained in a Comments field.  This brings the behavior in line with the SLS update script where a-priori the Xname cannot be known in an existing environment - for edge/Arista switches specifically.   Additionally it makes me a bit queasy to rely on an Xname in a Comments field.
* Added one more license header to stop the license check from complaining a bit.

#### Testing
* Tested on Wasp and Surtur data
* Ensured that the single Edge Router (Arista) on wasp generated the correct SLS data for "chn-switch-1" and that no switch 2 exists.
* On both environments tested that `bican-user-network-name` set to CHN and CAN both with and without the `retain-unused-user-network` flag generated the correct SLS data.
* On both environments tested that `bican-user-network-name` set to CHN and CAN both with and without the `retain-unused-user-network` flag generated the appropriate dnsmasq data.
* On both environments tested that `bican-user-network-name` set to CHN and CAN both with and without the `retain-unused-user-network` flag generated the appropriate UAN data.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Risks and Mitigations
 Generally the idea was to prevent generation of CHN or CAN early in the process.  For the CAN both dnsmasq and uan data were generated by explicit calls outside a loop.  Logic had to be put in placed further downstream to prevent program crashes.  The downstream placement is a sign that side effects might occur.  
