### PR TITLE
CASMINST-4421 and MTL-1659 add new chrony script to runcmd

### DIFF
--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -118,6 +118,7 @@ type BaseCampGlobals struct {
 var k8sRunCMD = []string{
 	"/srv/cray/scripts/metal/net-init.sh",
 	"/srv/cray/scripts/common/update_ca_certs.py",
+	"/srv/cray/scripts/metal/fix_chrony_configs.py",
 	"/srv/cray/scripts/metal/install.sh",
 	"/srv/cray/scripts/common/kubernetes-cloudinit.sh",
 	"/srv/cray/scripts/join-spire-on-storage.sh",
@@ -130,6 +131,7 @@ var k8sRunCMD = []string{
 var cephRunCMD = []string{
 	"/srv/cray/scripts/metal/net-init.sh",
 	"/srv/cray/scripts/common/update_ca_certs.py",
+	"/srv/cray/scripts/metal/fix_chrony_configs.py",
 	"/srv/cray/scripts/metal/install.sh",
 	"/srv/cray/scripts/common/pre-load-images.sh",
 	"/srv/cray/scripts/common/storage-ceph-cloudinit.sh",
@@ -142,6 +144,7 @@ var cephRunCMD = []string{
 var cephWorkerRunCMD = []string{
 	"/srv/cray/scripts/metal/net-init.sh",
 	"/srv/cray/scripts/common/update_ca_certs.py",
+	"/srv/cray/scripts/metal/fix_chrony_configs.py",
 	"/srv/cray/scripts/metal/install.sh",
 	"/srv/cray/scripts/common/pre-load-images.sh",
 	"touch /etc/cloud/cloud-init.disabled",


### PR DESCRIPTION


Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

#### Summary and Scope

- Partially implements: MTL-1659
- Relates to CASMINST-4421

##### Issue Type

- Bugfix Pull Request
- RFE Pull Request

Adds the new chrony script as a `runcmd` so NTP is configured on boot.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
#### Idempotency
 
Jinja deploys the correct config based on available metadata.
 
#### Risks and Mitigations
 
Medium.  This is adding a homegrown script to deploy NTP early in the install via a `runcmd`.
