### PR TITLE
CASMINST-4283: Add CMN route to net attach defs

### DIFF
--- a/pkg/pit/customizations_yaml.go
+++ b/pkg/pit/customizations_yaml.go
@@ -1,6 +1,25 @@
-/*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/
+//
+//  MIT License
+//
+//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
 
 package pit
 
@@ -211,16 +230,14 @@ func GenCustomizationsYaml(ncns []csi.LogicalNCN, shastaNetworks map[string]*csi
 		},
 	}
 	for netName, network := range shastaNetworks {
-		if strings.HasPrefix(netName, "NMN") {
-			if netName != "NMN" {
-				output.WLM.MacVlanSetup.Routes = append(output.WLM.MacVlanSetup.Routes, struct {
-					Destination string "yaml:\"dst\" valid:\"cidr,required\""
-					Gateway     string "yaml:\"gw\" valid:\"cidr,required\""
-				}{
-					Destination: network.CIDR,
-					Gateway:     uaiNet.Gateway.String(),
-				})
-			}
+		if netName == "NMNLB" || netName == "NMN_RVR" || netName == "NMN_MTN" || netName == "CMN" {
+			output.WLM.MacVlanSetup.Routes = append(output.WLM.MacVlanSetup.Routes, struct {
+				Destination string "yaml:\"dst\" valid:\"cidr,required\""
+				Gateway     string "yaml:\"gw\" valid:\"cidr,required\""
+			}{
+				Destination: network.CIDR,
+				Gateway:     uaiNet.Gateway.String(),
+			})
 		}
 	}
 	return output


### PR DESCRIPTION
#### Summary and Scope
We need prevent UAIs from getting to CMN like we do with NMNLB.   The way this is being accomplished with NMNLB is that a route exists on the UAI that goes to a gateway that it cannot get to.   We are doing the same thing for CMN by adding the CMN subnet to macvlan routes defined in customizations.yaml.  This causes it to be added to the relevant network attachment definitions.

- Fixes #CASMINST-4283

#### Prerequisites

- [x] I tested this on my laptop

I did a local build of CSI.  I ran "csi config init" with the resulting binary using the seed files from hela.   I verified that the correct CMN route (10.103.0.0./25) was added to the customizations.yaml generated by CSI.

```
  macvlansetup:
    nmn_subnet: 10.252.2.0/23
    nmn_supernet: 10.252.0.0/17
    nmn_supernet_gateway: 10.252.0.1
    nmn_vlan: bond0.nmn0
    nmn_reservation_start: 10.252.2.10
    nmn_reservation_end: 10.252.3.254
    routes:
    - dst: 10.100.0.0/17
      gw: 10.252.0.1
    - dst: 10.106.0.0/17
      gw: 10.252.0.1
    - dst: 10.103.0.0/25
      gw: 10.252.0.1
    - dst: 10.92.100.0/24
      gw: 10.252.0.1
```
 
