### PR TITLE
CASMINST-4549 1.2

### DIFF
--- a/pkg/csi/sls-state-generator.go
+++ b/pkg/csi/sls-state-generator.go
@@ -261,7 +261,7 @@ func (g *SLSStateGenerator) buildHardwareSection() (allHardware map[string]sls_c
 		nodeHardwareMap[nodeHardware.Xname] = nodeHardware
 
 		// Finally generate the network connection if there is one.
-		if strings.TrimSpace(row.DestinationPort) != "" {
+		if strings.TrimSpace(row.DestinationPort) != "" && strings.TrimSpace(row.DestinationPort) != "0" {
 			nodeConnection := g.getConnectionForNode(nodeHardware, row)
 			connectionHardwareMap[nodeConnection.Xname] = nodeConnection
 


### PR DESCRIPTION
#### Summary and Scope

- In order to have interoperability between the HMN-SHCD parser and CANU we need to be able to have 0 as a destination port number on the HMN tab of the SHCD.
- This change allows SLS to accept 0 as a port number.  This is the same behavior as leaving it blank.

- Fixes # CASMINST-4549

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) (if yes, please include results or a description of the test)
 
Tested locally.  All tests passed.
Generated SLS file has no differences with a "" or "0" as port destination.

#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->

Generated CSI data multiple times. 

#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->

