### PR TITLE
Replace Image

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -23,12 +23,12 @@
  *  OTHER DEALINGS IN THE SOFTWARE.
  *
  */
-
 @Library('csm-shared-library') _
 
 def promotionToken = ~"(main|release\\/.*)"
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME ==~ promotionToken ? true : false
 pipeline {
+
   agent {
     label "metal-gcp-builder"
   }
@@ -42,11 +42,14 @@ pipeline {
     BUILD_METADATA = getRpmRevision(isStable: isStable)
     GIT_REPO_NAME = getRepoName()
     GO_VERSION = sh(returnStdout: true, script: 'grep -Eo "^go .*" go.mod | cut -d " " -f2').trim()
+    VERSION = getDockerBuildVersion(isStable: isStable)
   }
 
   stages {
-    stage('Prepare') {
+
+    stage("Prepare: RPM") {
       steps {
+        runLibraryScript("addRpmMetaData.sh", env.SPEC_FILE)
         sh "make prepare"
       }
     }
@@ -54,11 +57,10 @@ pipeline {
     stage('Build: RPM') {
       agent {
         docker {
-          label 'docker'
-          image "artifactory.algol60.net/csm-docker/stable/sle15sp3_build_environment_golang:${env.GO_VERSION}"
-          registryUrl 'https://artifactory.algol60.net/'
-          registryCredentialsId 'artifactory-algol60'
+		  label 'docker'
           reuseNode true
+		  image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:${env.GO_VERSION}"
+          args "-v ${env.WORKSPACE}:/workspace"
         }
       }
       steps {
@@ -66,13 +68,19 @@ pipeline {
       }
     }
 
-    stage('Publish') {
+    stage('Publish: RPM') {
       steps {
         script {
           publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: isStable)
           publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: isStable)
         }
       }
+    }
+  }
+
+  post {
+    always {
+      postChownFiles()
     }
   }
 }


### PR DESCRIPTION
The previously used image was making use of a private key from an internal server. This image no longer contains internal security exploits, but contains the same toolset.