### PR TITLE
Fix metadata for SLES15SP3

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -35,6 +35,8 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(numToKeepStr: "10"))
+    disableConcurrentBuilds()
+    timeout(time: 20, unit: 'MINUTES')
     timestamps()
   }
 
@@ -48,8 +50,15 @@ pipeline {
   stages {
 
     stage("Prepare: RPM") {
+      agent {
+        docker {
+          label 'docker'
+          reuseNode true
+          image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:${env.GO_VERSION}"
+        }
+      }
       steps {
-        runLibraryScript("addRpmMetaData.sh", env.SPEC_FILE)
+        runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
         sh "make prepare"
       }
     }
@@ -60,7 +69,6 @@ pipeline {
 		  label 'docker'
           reuseNode true
 		  image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-go:${env.GO_VERSION}"
-          args "-v ${env.WORKSPACE}:/workspace"
         }
       }
       steps {


### PR DESCRIPTION
CSI is missing git information from its package description as well as a distribution value:
```
Name        : cray-site-init
Version     : 1.17.2
Release     : 1
Architecture: x86_64
Install Date: Tue 10 May 2022 07:51:25 PM UTC
Group       : Unspecified
Size        : 65889564
License     : MIT License
Signature   : (none)
Source RPM  : cray-site-init-1.17.2-1.src.rpm
Build Date  : Mon 09 May 2022 10:57:24 PM UTC
Build Host  : d618fa19fe2f
Relocations : (not relocatable)
Vendor      : Cray Inc.
Summary     : HPCaaS configuration and deployment tool for bare-metal or reinstallations
Description :
Installs the Cray Site Initiator GoLang binary onto a Linux system.
Distribution: (none)
```

This amends the following to the description while also setting a value for the distribution:
```
Description :
Git Repository: cray-site-init
Git Branch: metadata
Git Commit Revision: f50cccb8
Git Commit Timestamp: Fri May 20 17:05:13 2022 -0500

Installs the Cray Site Initiator GoLang binary onto a Linux system.
Distribution: SUSE Linux Enterprise Server 15 SP3
```