### PR TITLE
MTL-1497 add shellcheck

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+.github/                                @Cray-HPE/metal
+*                                       @Cray-HPE/metal
+pkg/pit                                 @Cray-HPE/metal
+pkg/csi                                 @Cray-HPE/metal
+pkg/version                             @Cray-HPE/metal
+cmd/cow.go                              @Cray-HPE/metal
+cmd/get.go                              @Cray-HPE/metal
+cmd/format.go                           @Cray-HPE/metal
+cmd/init.go                             @Cray-HPE/metal
+cmd/makedocs.go                         @Cray-HPE/metal
+cmd/pit.go                              @Cray-HPE/metal
+cmd/pitdata.go                          @Cray-HPE/metal
+cmd/populate.go                         @Cray-HPE/metal
+cmd/validate.go                         @Cray-HPE/metal
+write-livecd.sh                         @Cray-HPE/metal
+
+cmd/handoff.go                          @Cray-HPE/hardware-management
+cmd/handoff-bss-metadata.go             @Cray-HPE/hardware-management
+cmd/handoff-bss-update_cloud-init.go    @Cray-HPE/hardware-management
+cmd/handoff-bss-update_param.go         @Cray-HPE/hardware-management
+cmd/handoff-bss-update_param.go         @Cray-HPE/hardware-management

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+### Summary and Scope
+
+<!--- Pick one below and delete the rest -->
+<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->
+
+- Fixes:
+- Requires:
+- Relates to:
+
+#### Issue Type
+
+<!--- Delete un-needed bullets -->
+
+- Bugfix Pull Request
+- Docs Pull Request
+- RFE Pull Request
+
+<!--- words; describe what this change is and what it is for. -->
+
+### Prerequisites
+
+<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
+<!--- unchecked checkbox: [ ] -->
+<!--- checked checkbox: [x] -->
+<!--- invalid checkbox: [] -->
+
+- [ ] I have included documentation in my PR (or it is not required)
+- [ ] I tested this on internal system (if yes, please include results or a description of the test)
+- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
+ 
+### Idempotency
+ 
+<!--- describe testing done to verify code changes behave in an idempotent manner -->
+ 
+### Risks and Mitigations
+ 
+<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
+<!--- Example:
+
+This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
+is resolved and the overall risk of fatal failures is reduced.
+
+-->

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,43 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: shellcheck
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - lts/*
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: run shellcheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+        severity: error
+        ignore_paths: vendor


### PR DESCRIPTION
Updating release/1.2 with shellcheck for MTL-1497.

This comes in with the branch protection rules, so release and main branches can set the same rules. Right now release can't set shellcheck as a gate because it doesn't exist.

Also updates the PR template and CODEOWNERS.