### PR TITLE
CASMTRIAGE-3640 - Add all NMN and HMN networks to the NTP allow list

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,43 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: shellcheck
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - lts/*
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: run shellcheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+        severity: error
+        ignore_paths: vendor

--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -459,9 +459,14 @@ func MakeBaseCampfromNCNs(v *viper.Viper, ncns []csi.LogicalNCN, shastaNetworks 
 
 		// ntp allowed networks should be a list of NMN and HMN CIDRS
 		var nmnNets []string
-		for _, netNetwork := range ncn.Networks {
-			// get this for ntp:
-			nmnNets = append(nmnNets, netNetwork.CIDR)
+
+		// Need to exclude the BICAN toggle network and the NMNLB/HMNLB networks.
+		for _, netNetwork := range shastaNetworks {
+			if (strings.Contains(netNetwork.Name, "HMN") ||
+				strings.Contains(netNetwork.Name, "NMN")) &&
+				!strings.Contains(netNetwork.Name, "LB") {
+				nmnNets = append(nmnNets, netNetwork.CIDR)
+			}
 		}
 
 		// for use with the timezone cloud-init module


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMTRIAGE-3640](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3640)

#### Issue Type

- Bugfix Pull Request

`csi` currently looks at the list of networks associated with an NCN to build the NTP allow list however this does not include the NMN_RVR, NMN_MTN, HMN_RVR, and HMN_MTN networks.

This change causes all the NMN/HMN networks to be included excluding the NMNLB and HMNLB networks.

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

Using seed data from `hela` the generated NTP allow list is as follows.
```
        "allow": [
          "10.103.9.10/25",
          "10.252.1.9/17",
          "10.103.0.24/25",
          "10.254.1.14/17",
          "10.1.1.7/16"
        ],
```
With code change
```
        "allow": [
          "10.252.0.0/17",
          "10.100.0.0/17",
          "10.254.0.0/17",
          "10.104.0.0/17",
          "10.107.0.0/17",
          "10.106.0.0/17"
        ],
```
 
### Idempotency
 

 
### Risks and Mitigations
 

