### PR TITLE
CASMTRIAGE-3640 - Add all NMN and HMN networks to the NTP allow list

### DIFF
--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -459,9 +459,14 @@ func MakeBaseCampfromNCNs(v *viper.Viper, ncns []csi.LogicalNCN, shastaNetworks 
 
 		// ntp allowed networks should be a list of NMN and HMN CIDRS
 		var nmnNets []string
-		for _, netNetwork := range ncn.Networks {
-			// get this for ntp:
-			nmnNets = append(nmnNets, netNetwork.CIDR)
+
+		// Need to exclude the BICAN toggle network and the NMNLB/HMNLB networks.
+		for _, netNetwork := range shastaNetworks {
+			if (strings.Contains(netNetwork.Name, "HMN") ||
+				strings.Contains(netNetwork.Name, "NMN")) &&
+				!strings.Contains(netNetwork.Name, "LB") {
+				nmnNets = append(nmnNets, netNetwork.CIDR)
+			}
 		}
 
 		// for use with the timezone cloud-init module


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMTRIAGE-3640](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3640)

#### Issue Type

- Bugfix Pull Request

`csi` currently looks at the list of networks associated with an NCN to build the NTP allow list however this does not include the NMN_RVR, NMN_MTN, HMN_RVR, and HMN_MTN networks.

This change causes all the NMN/HMN networks to be included (excluding the NMNLB and HMNLB networks).

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

Using seed data from `hela` the generated NTP allow list is as follows.
```
        "allow": [
          "10.103.9.10/25",
          "10.252.1.9/17",
          "10.103.0.24/25",
          "10.254.1.14/17",
          "10.1.1.7/16"
        ],
```
With code change
```
        "allow": [
          "10.252.0.0/17",
          "10.100.0.0/17",
          "10.254.0.0/17",
          "10.104.0.0/17",
          "10.107.0.0/17",
          "10.106.0.0/17"
        ],
```
 
### Idempotency
 

 
### Risks and Mitigations
 