### PR TITLE
MTL-1836 Remove App Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ TAG?=latest
 .GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 .GIT_COMMIT_AND_BRANCH=$(.GIT_COMMIT)-$(subst /,-,$(.GIT_BRANCH))
 .GIT_VERSION=$(shell git describe --tags 2>/dev/null || echo "$(.GIT_COMMIT)")
-.FS_VERSION=$(shell cat .version)
 .BUILDTIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 CHANGELOG_VERSION_ORIG=$(grep -m1 \## CHANGELOG.MD | sed -e "s/\].*\$//" |sed -e "s/^.*\[//")
 CHANGELOG_VERSION=$(shell grep -m1 \ \[[0-9]*.[0-9]*.[0-9]*\] CHANGELOG.MD | sed -e "s/\].*$$//" |sed -e "s/^.*\[//")
@@ -146,8 +145,7 @@ reset:
 
 build: fmt
 	go build -o bin/csi -ldflags "\
-	-X github.com/Cray-HPE/cray-site-init/pkg/version.gitVersion=${.GIT_VERSION} \
-	-X github.com/Cray-HPE/cray-site-init/pkg/version.fsVersion=${.FS_VERSION} \
+	-X github.com/Cray-HPE/cray-site-init/pkg/version.version=${.GIT_VERSION} \
 	-X github.com/Cray-HPE/cray-site-init/pkg/version.buildDate=${.BUILDTIME} \
 	-X github.com/Cray-HPE/cray-site-init/pkg/version.sha1ver=${.GIT_COMMIT_AND_BRANCH}"
 	bin/csi version

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,10 +23,6 @@ var versionCmd = &cobra.Command{
 		v := viper.GetViper()
 		v.BindPFlags(cmd.Flags())
 		clientVersion := version.Get()
-		if v.GetBool("simple") {
-			fmt.Printf("%v.%v\n", clientVersion.Major, clientVersion.Minor)
-			os.Exit(0)
-		}
 		if v.GetBool("git") {
 			fmt.Println(clientVersion.GitCommit)
 			os.Exit(0)
@@ -37,9 +33,8 @@ var versionCmd = &cobra.Command{
 			fmt.Printf("%-15s: %s\n", "Build Commit", clientVersion.GitCommit)
 			fmt.Printf("%-15s: %s\n", "Build Time", clientVersion.BuildDate)
 			fmt.Printf("%-15s: %s\n", "Go Version", clientVersion.GoVersion)
-			fmt.Printf("%-15s: %s\n", "Git Version", clientVersion.GitVersion)
+			fmt.Printf("%-15s: %s\n", "Version", clientVersion.Version)
 			fmt.Printf("%-15s: %s\n", "Platform", clientVersion.Platform)
-			fmt.Printf("%-15s: %v.%v.%v\n", "App. Version", clientVersion.Major, clientVersion.Minor, clientVersion.FixVr)
 		case "json":
 			b, err := json.Marshal(clientVersion)
 			if err != nil {
@@ -55,6 +50,5 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	versionCmd.DisableAutoGenTag = true
 	versionCmd.Flags().StringP("output", "o", "pretty", "output format pretty,json")
-	versionCmd.Flags().BoolP("simple", "s", false, "Simple version on a single line")
 	versionCmd.Flags().BoolP("git", "g", false, "Simple commit sha of the source tree on a single line. \"-dirty\" added to the end if uncommitted changes present")
 }

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -1,12 +1,8 @@
 package version
 
 var (
-	sha1ver    string                   // sha1 revision used to build the program
-	gitVersion string                   // git tag version
-	fsVersion  string                   // .version contents
-	buildTime  string                   // when the executable was built
-	fsMajor    string                   // major version, always numeric
-	fsMinor    string                   // minor version, always numeric
-	fsFixVr    string                   // fixvr version (bugfix / hotfix / non-contextually changing mod, numeric possibly followed by "+"
-	buildDate  = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	sha1ver   string                   // sha1 revision used to build the program
+	version   string                   // git tag version
+	buildTime string                   // when the executable was built
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,25 +3,21 @@ package version
 import (
 	"fmt"
 	"runtime"
-	"strings"
 )
 
 // Info is heavily informed by the Kubernetes Versioning System.
 type Info struct {
-	Major      string `json:"major"`
-	Minor      string `json:"minor"`
-	FixVr      string `json:"fixvr"`
-	GitVersion string `json:"gitVersion"`
-	GitCommit  string `json:"gitCommit"`
-	BuildDate  string `json:"buildDate"`
-	GoVersion  string `json:"goVersion"`
-	Compiler   string `json:"compiler"`
-	Platform   string `json:"platform"`
+	Version   string `json:"version"`
+	GitCommit string `json:"gitCommit"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+	Compiler  string `json:"compiler"`
+	Platform  string `json:"platform"`
 }
 
 // String returns info as a human-friendly version string.
 func (info Info) String() string {
-	return info.GitVersion
+	return info.Version
 }
 
 // Get returns the overall codebase version. It's for detecting
@@ -30,25 +26,12 @@ func Get() Info {
 	// These variables typically come from -ldflags settings and in
 	// their absence fallback to the settings in ./base.go
 
-	// If major and minor are not individually set with ldflags, we can
-	// separate the .version file as passed with an ldflag
-	if fsMajor == "" && fsMinor == "" {
-		if fsVersion != "" {
-			fsVersions := strings.Split(fsVersion, ".")
-			fsMajor = fsVersions[0]
-			fsMinor = fsVersions[1]
-			fsFixVr = fsVersions[2]
-		}
-	}
 	return Info{
-		Major:      fsMajor,
-		Minor:      fsMinor,
-		FixVr:      fsFixVr,
-		GitVersion: gitVersion,
-		GitCommit:  sha1ver,
-		BuildDate:  buildDate,
-		GoVersion:  runtime.Version(),
-		Compiler:   runtime.Compiler,
-		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Version:   version,
+		GitCommit: sha1ver,
+		BuildDate: buildDate,
+		GoVersion: runtime.Version(),
+		Compiler:  runtime.Compiler,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1836
- Relates to: #179 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

App Version reports '..' as its version since the removal of the `.version` file.


```bash
CRAY-Site-Init build signature...
Build Commit   : d034152d80558e7463fc3ccf1675b03b2c9ef86d-MTL-1836-dirty
Build Time     : 2022-07-05T16:06:38Z
Go Version     : go1.16.3
Version        : v1.20.1-1-gd034152d
Platform       : darwin/amd64
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
