### PR TITLE
MTL-1849: Fix TestCabinetDefinitionWithHill after EX2500 cabinet support added

### DIFF
--- a/cmd/cabinet_input_file_test.go
+++ b/cmd/cabinet_input_file_test.go
@@ -8,6 +8,7 @@ Copyright 2021 Hewlett Packard Enterprise Development LP
 package cmd
 
 import (
+	"encoding/json"
 	"log"
 	"testing"
 
@@ -38,6 +39,17 @@ func testProcessWithHill(t *testing.T) csi.CabinetDetailFile {
 	return cabDetailFile
 }
 
+func testFindCabinetGroupDetail(t *testing.T, cabinetDetailList []csi.CabinetGroupDetail, wantedKind csi.CabinetKind) *csi.CabinetGroupDetail {
+	for _, cabinetDetail := range cabinetDetailList {
+		if cabinetDetail.Kind == wantedKind {
+			return &cabinetDetail
+		}
+	}
+
+	t.Errorf("Failed to kind %s in cabinetDetailList", wantedKind)
+	return nil
+}
+
 func TestCabinetDefinitionWithHill(t *testing.T) {
 	cabDetailFile := testProcessWithHill(t)
 	cabDefinitions := make(map[csi.CabinetKind]cabinetDefinition)
@@ -55,8 +67,41 @@ func TestCabinetDefinitionWithHill(t *testing.T) {
 	}
 
 	cabinetDetailList := buildCabinetDetails(cabDefinitions, cabDetailFile)
-	if len(cabinetDetailList) != 3 {
+	if len(cabinetDetailList) != len(csi.ValidCabinetTypes) {
 		t.Errorf("%+v", cabinetDetailList)
 	}
-	log.Printf("%+v \n", cabinetDetailList)
+
+	// Hill
+	hill := testFindCabinetGroupDetail(t, cabinetDetailList, csi.CabinetKindHill)
+	if hill.Cabinets != 1 {
+		t.Errorf("Expected 1 hill cabinet, but got %v", hill.Cabinets)
+	}
+
+	// Mountain
+	mountain := testFindCabinetGroupDetail(t, cabinetDetailList, csi.CabinetKindMountain)
+	if mountain.Cabinets != 20 {
+		t.Errorf("Expected 20 mountain cabinets, but got %v", mountain.Cabinets)
+	}
+
+	// River
+	river := testFindCabinetGroupDetail(t, cabinetDetailList, csi.CabinetKindRiver)
+	if river.Cabinets != 1 {
+		t.Errorf("Expected 1 river cabinet, but got %v", river.Cabinets)
+	}
+
+	// The EX{20,25,30,40}00 cabinet kinds are expected to be 0
+	for _, cabinetKind := range []csi.CabinetKind{csi.CabinetKindEX2000, csi.CabinetKindEX2500, csi.CabinetKindEX3000, csi.CabinetKindEX4000} {
+		cabinetGroupDetail := testFindCabinetGroupDetail(t, cabinetDetailList, cabinetKind)
+		if cabinetGroupDetail.Cabinets != 0 {
+			t.Errorf("Expected 0 %v cabinets, but got %v", cabinetKind, cabinetGroupDetail.Cabinets)
+		}
+	}
+
+	// Make the cabinet detail list a bit more readable
+	cabinetDetailListJSON, err := json.MarshalIndent(cabinetDetailList, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("%+v \n", string(cabinetDetailListJSON))
 }


### PR DESCRIPTION
### Summary and Scope
- Fixes: MTL-1849

#### Issue Type

- Bugfix Pull Request

### Prerequisites
- [X] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
The `TestCabinetDefinitionWithHill` unit test wasn't fully updated after the https://github.com/Cray-HPE/cray-site-init/pull/203 was merged. Basically the test needs to be aware of the new EX{20,25,30,40}00 cabinet kinds.

As a sanity check I backported my test fix into the `release/1.2` code base, and observed that it passed: https://github.com/Cray-HPE/cray-site-init/compare/release/1.2...bugfix/MTL-1849-csm-1.2?expand=1 

I also took a note of the contents of the `cabinetDetailList` variable was to compare it with the contents of it on the `main` branch as a sanity check to verify my changes in https://github.com/Cray-HPE/cray-site-init/pull/203 adversely affected it.

From the release 1.2 branch for what the contents of `cabinetDetailList`` looks like in JSON: 
```json
2022/07/13 16:52:44 [
  {
    "Kind": "river",
    "Cabinets": 1,
    "StartingCabinet": 0,
    "CabinetDetails": [
      {
        "ID": 3000,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      }
    ]
  },
  {
    "Kind": "hill",
    "Cabinets": 1,
    "StartingCabinet": 0,
    "CabinetDetails": [
      {
        "ID": 9000,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      }
    ]
  },
  {
    "Kind": "mountain",
    "Cabinets": 20,
    "StartingCabinet": 200,
    "CabinetDetails": [
      {
        "ID": 200,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 201,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 202,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 203,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 204,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 205,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 206,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 207,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 208,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 209,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 210,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 211,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 212,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 213,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 214,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 215,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 216,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 217,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 218,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      },
      {
        "ID": 219,
        "NMNSubnet": "",
        "NMNVlanID": 0,
        "HMNSubnet": "",
        "HMNVlanID": 0
      }
    ]
  }
] 
```

What is looks like in main branch (the EX* cabinets are expected to be empty none of those cabinet types have been specified).
```json
2022/07/13 16:56:32 [
    {
      "Kind": "river",
      "Cabinets": 1,
      "StartingCabinet": 0,
      "CabinetDetails": [
        {
          "ID": 3000,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        }
      ]
    },
    {
      "Kind": "hill",
      "Cabinets": 1,
      "StartingCabinet": 0,
      "CabinetDetails": [
        {
          "ID": 9000,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        }
      ]
    },
    {
      "Kind": "mountain",
      "Cabinets": 20,
      "StartingCabinet": 200,
      "CabinetDetails": [
        {
          "ID": 200,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 201,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 202,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 203,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 204,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 205,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 206,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 207,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 208,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 209,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 210,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 211,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 212,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 213,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 214,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 215,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 216,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 217,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 218,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        },
        {
          "ID": 219,
          "ChassisCount": null,
          "NMNSubnet": "",
          "NMNVlanID": 0,
          "HMNSubnet": "",
          "HMNVlanID": 0
        }
      ]
    },
    {
      "Kind": "EX2000",
      "Cabinets": 0,
      "StartingCabinet": 0,
      "CabinetDetails": null
    },
    {
      "Kind": "EX2500",
      "Cabinets": 0,
      "StartingCabinet": 0,
      "CabinetDetails": null
    },
    {
      "Kind": "EX3000",
      "Cabinets": 0,
      "StartingCabinet": 0,
      "CabinetDetails": null
    },
    {
      "Kind": "EX4000",
      "Cabinets": 0,
      "StartingCabinet": 0,
      "CabinetDetails": null
    }
  ] 
```

The only changes where the additions of the `EX2000`, `EX2500`, `EX3000`, and `EX4000` cabinet types. All of them have 0 cabinets as expected. 
 
### Risks and Mitigations
Low risk.

