### PR TITLE
MTL-1850 Fix TestCreateApplicationNodeConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 bin/
 coverage*
 build/
-cmd/*/*
 !cmd/embeded-files/*
 dist/
-cmd/application_node_config.yaml
-cmd/hmn_connections.json
-cmd/ncn_metadata.csv
-cmd/switch_metadata.csv

--- a/.license_check.yaml
+++ b/.license_check.yaml
@@ -23,4 +23,5 @@
 #
 add_exclude:
   - cmd/*_test.go
+  - testdata/expected/*
   - vendor

--- a/cmd/shcd_test.go
+++ b/cmd/shcd_test.go
@@ -36,6 +36,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/Cray-HPE/cray-site-init/pkg/shcd"
@@ -57,6 +58,7 @@ func TestCreateHMNConnections(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+	defer syscall.Unlink(filepath.Join(".", hmnConnections))
 	// Validate the file was created
 	_, err = os.Stat(filepath.Join(".", hmnConnections))
 	if err != nil {
@@ -102,6 +104,7 @@ func TestCreateSwitchMetadata(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer syscall.Unlink(filepath.Join(".", switchMetadata))
 	// Read the csv and validate it's contents
 	generated, err := os.Open(filepath.Join(".", switchMetadata))
 	if err != nil {
@@ -144,6 +147,7 @@ func TestCreateNCNMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	defer syscall.Unlink(filepath.Join(".", ncnMetadata))
 	// Validate the file was created
 	_, err = os.Stat(filepath.Join(".", ncnMetadata))
 	if err != nil {
@@ -200,6 +204,7 @@ func TestCreateApplicationNodeConfig(t *testing.T) {
 	}
 	// Validate the file was created
 	_, err = os.Stat(filepath.Join(".", applicationNodeConfig))
+	defer syscall.Unlink(filepath.Join(".", applicationNodeConfig))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/csi/sls-state-generator.go
+++ b/pkg/csi/sls-state-generator.go
@@ -1,4 +1,52 @@
-// Copyright 2021 Hewlett Packard Enterprise Development LP
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+/*
+
+MIT License
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
 
 package csi
 

--- a/pkg/csi/sls-state-generator_test.go
+++ b/pkg/csi/sls-state-generator_test.go
@@ -440,6 +440,7 @@ var TestSLSInputState = SLSGeneratorInputState{
 			Xname: xnames.Cabinet{
 				Cabinet: 3000,
 			},
+			Class: sls_common.ClassRiver,
 			// Model: , Not applicable???
 			AirCooledChassisList:    DefaultRiverChassisList,
 			LiquidCooledChassisList: []int{},
@@ -666,12 +667,12 @@ func (suite *ConfigGeneratorTestSuite) SetupSuite() {
 
 func (suite *ConfigGeneratorTestSuite) TestVerifyNoEmptyHardware() {
 	for xname, hardware := range suite.allHardware {
-		suite.NotEmpty(xname)
-		suite.NotEmpty(hardware.Xname)
-		suite.NotEmpty(hardware.Parent)
-		suite.NotEmpty(hardware.Type)
-		suite.NotEmpty(hardware.TypeString)
-		suite.NotEmpty(hardware.Class)
+		suite.NotEmpty(xname, "xname key is empty")
+		suite.NotEmpty(hardware.Xname, "Xname is empty for %s", xname)
+		suite.NotEmpty(hardware.Parent, "Parent is empty for %s", xname)
+		suite.NotEmpty(hardware.Type, "Type is empty for %s", xname)
+		suite.NotEmpty(hardware.TypeString, "TypeString is empty for %s", xname)
+		suite.NotEmpty(hardware.Class, "Class is empty for %s", xname)
 
 		// Note: The extra properties field maybe empty for some component types
 	}

--- a/pkg/csi/sls-state-generator_test.go
+++ b/pkg/csi/sls-state-generator_test.go
@@ -448,7 +448,7 @@ var TestSLSInputState = SLSGeneratorInputState{
 		},
 		"x3001": SLSCabinetTemplate{
 			Xname: xnames.Cabinet{
-				Cabinet: 3000,
+				Cabinet: 3001,
 			},
 			Class: sls_common.ClassRiver,
 			// Model: , Not applicable???
@@ -1527,7 +1527,7 @@ func (suite *ConfigGeneratorTestSuite) TestCabinet_River() {
 	/*
 		{
 			"Parent": "s0",
-			"Xname": "x3000",
+			"Xname": "x3001",
 			"Type": "comptype_cabinet",
 			"Class": "River",
 			"TypeString": "Cabinet",
@@ -1535,11 +1535,11 @@ func (suite *ConfigGeneratorTestSuite) TestCabinet_River() {
 		}
 	*/
 
-	hardware, ok := suite.allHardware["x3000"]
+	hardware, ok := suite.allHardware["x3001"]
 	suite.True(ok, "Unable to find xname.")
 
 	suite.Equal(hardware.Parent, "s0")
-	suite.Equal(hardware.Xname, "x3000")
+	suite.Equal(hardware.Xname, "x3001")
 	suite.Equal(hardware.Type, sls_common.HMSStringType("comptype_cabinet"))
 	suite.Equal(hardware.Class, sls_common.CabinetType("River"))
 	suite.Equal(hardware.TypeString, xnametypes.HMSType("Cabinet"))

--- a/pkg/csi/sls-state-generator_test.go
+++ b/pkg/csi/sls-state-generator_test.go
@@ -1,7 +1,31 @@
 //go:build !integration && !shcd
 // +build !integration,!shcd
 
-// Copyright 2021 Hewlett Packard Enterprise Development LP
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
 
 package csi
 

--- a/pkg/csi/sls.go
+++ b/pkg/csi/sls.go
@@ -1,5 +1,51 @@
 /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+/*
+
+MIT License
+
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 */
 
 package csi

--- a/pkg/csi/sls_test.go
+++ b/pkg/csi/sls_test.go
@@ -2,9 +2,30 @@
 // +build !integration,!shcd
 
 /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/
-
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
 package csi
 
 import (

--- a/testdata/expected/application_node_config.yaml
+++ b/testdata/expected/application_node_config.yaml
@@ -1,26 +1,3 @@
-#
-# MIT License
-#
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
 ---
 # Additional application node prefixes to match in the hmn_connections.json file
 prefixes:


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1850
- Relates to: MTL-1848

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The test was working but the LICENSE included in the expected test file was causing the test to flunk the comparison of actual to expected.

This updates `.license_check.yaml` to ignore `testdata/expected/*` files, and also removes created files from tests in `cmd/shcd_test.go`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
