### PR TITLE
CASMUSER-3028: Add a blackhole route for the HMN and HMNLB

### DIFF
--- a/pkg/pit/customizations_yaml.go
+++ b/pkg/pit/customizations_yaml.go
@@ -230,7 +230,7 @@ func GenCustomizationsYaml(ncns []csi.LogicalNCN, shastaNetworks map[string]*csi
 		},
 	}
 	for netName, network := range shastaNetworks {
-		if netName == "NMNLB" {
+		if netName == "NMNLB" || netName == "HMN" || netName == "HMNLB" {
 			output.WLM.MacVlanSetup.Routes = append(output.WLM.MacVlanSetup.Routes, struct {
 				Destination string "yaml:\"dst\" valid:\"cidr,required\""
 				Gateway     string "yaml:\"gw\" valid:\"cidr,required\""


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMUSER-3028
- Fixes CASMUSER-3050

##### Issue Type

- Bugfix Pull Request

CSI adds "routes" for the UAI net-attach-definition customizations to invalid IPs as a blackhole for traffic that should not go out the weave net over the default route.

Add two new routes for HMN and HMNLB.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (x) 

I tested this with the net-attach-def set to ipvlan/hsn and macvlan/nmn. I pulled the new routes from a locally built `csi` using hermod seed files. The new routes are shown here:
```
    routes:
    - dst: 10.92.100.0/24        <-- new HMNLB
      gw: 10.252.2.6
    - dst: 10.254.0.0/17        <-- new HMN
      gw: 10.252.2.6
    - dst: 10.101.3.0/25
      gw: 10.252.0.1
    - dst: 10.94.100.0/24
      gw: 10.252.2.6
    - dst: 10.106.0.0/17
      gw: 10.252.0.1
```

With a modified net-attach-def including these routes, I could not hit IPs on those networks as intended. This was done over ipvlan/hsn and macvlan/nmn configurations on hermod.
 
#### Idempotency
 
Ran `csi config init` on hermod's seed files 
 
#### Risks and Mitigations
 
Risk that somehow the routes aren't configured right. Result would be UAIs or WLM pods stuck in ContainerCreating. Mitigation would be to run `kubectl edit -n user net-attach-def` and remove the new routes.
