### PR TITLE
MTL-1858 Script moved to subdir

### DIFF
--- a/pkg/bss/types.go
+++ b/pkg/bss/types.go
@@ -32,7 +32,7 @@ var KubernetesNCNRunCMD = [...]string{
 	"/srv/cray/scripts/common/update_ca_certs.py",
 	"/srv/cray/scripts/metal/install.sh",
 	"/srv/cray/scripts/common/kubernetes-cloudinit.sh",
-	"/srv/cray/scripts/join-spire-on-storage.sh",
+	"/srv/cray/scripts/common/join-spire-on-storage.sh",
 	"touch /etc/cloud/cloud-init.disabled",
 }
 

--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -120,7 +120,7 @@ var k8sRunCMD = []string{
 	"/srv/cray/scripts/common/update_ca_certs.py",
 	"/srv/cray/scripts/metal/install.sh",
 	"/srv/cray/scripts/common/kubernetes-cloudinit.sh",
-	"/srv/cray/scripts/join-spire-on-storage.sh",
+	"/srv/cray/scripts/common/join-spire-on-storage.sh",
 	"touch /etc/cloud/cloud-init.disabled",
 }
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1858 https://github.com/Cray-HPE/node-images/pull/420

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The `join-spire-on-storage.sh` script was lingering in a random folder, it was moved by MTL-1858 into a subdir. This code changes the runcmd to invoke it in the new place.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
