### PR TITLE
MTL-1876 Private Buckets for Upgrades

### DIFF
--- a/cmd/upgrade-metadata.go
+++ b/cmd/upgrade-metadata.go
@@ -612,22 +612,22 @@ func updateBSS12to13() (err error) {
 		case "Storage":
 			bootparameters.CloudInit.UserData["runcmd"] = bss.StorageNCNRunCMD
 			if storageVersion != "" {
-				bootparameters.Initrd = fmt.Sprintf("s3://ncn-images/ceph/%s/initrd", storageVersion)
-				bootparameters.Kernel = fmt.Sprintf("s3://ncn-images/ceph/%s/kernel", storageVersion)
+				bootparameters.Initrd = fmt.Sprintf("%s/%s/%s/%s", s3Prefix, cephPath, storageVersion, initrdName)
+				bootparameters.Kernel = fmt.Sprintf("%s/%s/%s/%s", s3Prefix, cephPath, storageVersion, kernelName)
 				setMetalServerParam := paramTuple{
 					key:   "metal.server",
-					value: fmt.Sprintf("http://rgw-vip.nmn/ncn-images/ceph/%s", storageVersion),
+					value: fmt.Sprintf("%s/%s/%s/%s", s3Prefix, cephPath, storageVersion, rootfsName),
 				}
 				UpgradeParamsToSet = append(UpgradeParamsToSet, setMetalServerParam)
 			}
 		case "Master", "Worker":
 			bootparameters.CloudInit.UserData["runcmd"] = bss.KubernetesNCNRunCMD
 			if k8sVersion != "" {
-				bootparameters.Initrd = fmt.Sprintf("s3://ncn-images/k8s/%s/initrd", k8sVersion)
-				bootparameters.Kernel = fmt.Sprintf("s3://ncn-images/k8s/%s/kernel", k8sVersion)
+				bootparameters.Initrd = fmt.Sprintf("%s/%s/%s/%s", s3Prefix, k8sPath, k8sVersion, initrdName)
+				bootparameters.Kernel = fmt.Sprintf("%s/%s/%s/%s", s3Prefix, k8sPath, k8sVersion, kernelName)
 				setMetalServerParam := paramTuple{
 					key:   "metal.server",
-					value: fmt.Sprintf("http://rgw-vip.nmn/ncn-images/k8s/%s", k8sVersion),
+					value: fmt.Sprintf("%s/%s/%s/%s", s3Prefix, k8sPath, k8sVersion, rootfsName),
 				}
 				UpgradeParamsToSet = append(UpgradeParamsToSet, setMetalServerParam)
 			}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1876

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This change switches the `updateBSS12to13()` function to set the NCNs to use private buckets.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
