### PR TITLE
CASMINST-5290 Fix `bss-metadata`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,5 @@ write-livecd.sh                         @Cray-HPE/metal
 
 cmd/handoff.go                          @Cray-HPE/hardware-management
 cmd/handoff-bss-metadata.go             @Cray-HPE/hardware-management
-cmd/handoff-bss-update_cloud-init.go    @Cray-HPE/hardware-management
-cmd/handoff-bss-update_param.go         @Cray-HPE/hardware-management
-cmd/handoff-bss-update_param.go         @Cray-HPE/hardware-management
+cmd/handoff-bss-update-cloud-init.go    @Cray-HPE/hardware-management
+cmd/handoff-bss-update-param.go         @Cray-HPE/hardware-management

--- a/cmd/handoff-bss-metadata.go
+++ b/cmd/handoff-bss-metadata.go
@@ -121,31 +121,43 @@ var handoffBSSMetadataCmd = &cobra.Command{
 			fmt.Println(err)
 		}
 
+		if kubernetesVersion == "" && kubernetesFile == "" && storageCephVersion == "" && storageCephFile == "" {
+			log.Fatalln("ERROR: Missing (--kubernetes-version && --storage-ceph-version) or (--kubernetes-file && --storage-ceph-file), either of the parameter groups needs to be specified.")
+		}
+
 		if kubernetesVersion == "" {
 			kubernetes := path.Base(kubernetesFile)
-			desiredKubernetesVersion = fileVersionRegex.FindStringSubmatch(kubernetes)[1]
-			if desiredKubernetesVersion == "" {
+			desiredKubernetesVersionMatch := fileVersionRegex.FindStringSubmatch(kubernetes)
+			if desiredKubernetesVersionMatch == nil {
 				log.Fatalf("ERROR: Could not determine version from [%s]", kubernetesFile)
+			} else {
+				desiredKubernetesVersion = desiredKubernetesVersionMatch[1]
 			}
 
 		} else {
-			desiredKubernetesVersion = versionRegex.FindStringSubmatch(kubernetesVersion)[1]
-			if desiredKubernetesVersion == "" {
+			desiredKubernetesVersionMatch := versionRegex.FindStringSubmatch(kubernetesVersion)
+			if desiredKubernetesVersionMatch == nil {
 				log.Fatalf("ERROR: Could not determine version from [%s]", kubernetesVersion)
+			} else {
+				desiredKubernetesVersion = desiredKubernetesVersionMatch[1]
 			}
 
 		}
 		if storageCephVersion == "" {
 			storageCeph := path.Base(storageCephFile)
-			desiredCephVersion = fileVersionRegex.FindStringSubmatch(storageCeph)[1]
-			if desiredCephVersion == "" {
+			desiredCephVersionMatch := fileVersionRegex.FindStringSubmatch(storageCeph)
+			if desiredCephVersionMatch == nil {
 				log.Fatalf("ERROR: Could not determine version from [%s]", storageCephFile)
+			} else {
+				desiredCephVersion = desiredCephVersionMatch[1]
 			}
 		} else {
 			// Validate the version input.
-			desiredCephVersion = versionRegex.FindStringSubmatch(storageCephVersion)[0]
-			if desiredCephVersion == "" {
+			desiredCephVersionMatch := versionRegex.FindStringSubmatch(storageCephVersion)
+			if desiredCephVersionMatch == nil {
 				log.Fatalf("ERROR: Could not determine version from [%s]", storageCephVersion)
+			} else {
+				desiredCephVersion = desiredCephVersionMatch[1]
 			}
 		}
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-5290
- Relates to: MTL-1876 #232 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This ensures that either of the mutually exclusive groups are required when invoking `csi handoff bss-metadata`, while also removing the possibility of hitting a slicing error on bad regex matches.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
