### PR TITLE
MTL-1695 `pit populate` is no longer used

### DIFF
--- a/cmd/populate.go
+++ b/cmd/populate.go
@@ -17,6 +17,8 @@ import (
 )
 
 // populateCmd moves csi files and node images onto the usb device
+// Deprecated: The USB path no longer uses this function since it is now completely identical to the
+// RemoteISO path for configuring the PIT.
 var populateCmd = &cobra.Command{
 	Use:   "populate",
 	Short: "Populates the LiveCD with configs",
@@ -24,6 +26,7 @@ var populateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("populate called")
 	},
+	Deprecated: "No longer used for CSM 1.3 or newer CSM installations.",
 }
 
 // copyAllFiles copies ONLY files from one spot to another

--- a/cmd/populate.go
+++ b/cmd/populate.go
@@ -1,8 +1,30 @@
-package cmd
-
 /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package cmd
 
 import (
 	"fmt"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1695

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Deprecates `csi pit populate`.

Now `pit populate` isn't shown in the usage, but if it is invoked it'll print this message:
```
Command "populate" is deprecated, No longer used for CSM 1.3 or newer CSM installations.
```


Before:
```bash
surtur-ncn-m001-pit:~ # csi pit --help

Interact with the Pre-Install Toolkit (LiveCD);
create, validate, or re-create a new or old USB stick with
the liveCD tool. Fetches artifacts for deployment.

Usage:
  csi pit [flags]
  csi pit [command]

Available Commands:
  format      Formats a disk as a LiveCD
  get         Downloads artifacts
  populate    Populates the LiveCD with configs
  validate    Runs unit tests

Flags:
  -h, --help   help for pit

Global Flags:
      --config string   config file

Use "csi pit [command] --help" for more information about a command.
```

After, the `populate command is gone but still can be used.
```bash
redbull-ncn-m001-pit:~ #  csi pit --help

Interact with the Pre-Install Toolkit (LiveCD);
create, validate, or re-create a new or old USB stick with
the liveCD tool. Fetches artifacts for deployment.

Usage:
  csi pit [flags]
  csi pit [command]

Available Commands:
  format      Formats a disk as a LiveCD
  get         Downloads artifacts
  validate    Runs unit tests

Flags:
  -h, --help   help for pit

Global Flags:
      --config string   config file

Use "csi pit [command] --help" for more information about a command.
redbull-ncn-m001-pit:~ # csi pit populate --help
Command "populate" is deprecated, No longer used for CSM 1.3 or newer CSM installations.
Populates the LiveCD with network interface configs after running the format command.

Usage:
  csi pit populate [flags]
  csi pit populate [command]

Available Commands:
  cow         Populates the cow partition with necessary config files
  pitdata     Populates the PITDATA partition with necessary config files

Flags:
  -h, --help   help for populate

Global Flags:
      --config string   config file

Use "csi pit populate [command] --help" for more information about a command.
```


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
