### PR TITLE
improve auto seed file generation accuracy

### DIFF
--- a/cmd/shcd.go
+++ b/cmd/shcd.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Cray-HPE/cray-site-init/pkg/csi"
 	"github.com/Cray-HPE/cray-site-init/pkg/shcd"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
@@ -76,12 +77,14 @@ var shcdCmd = &cobra.Command{
 	`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		v := viper.GetViper()
+		v.BindPFlags(cmd.Flags())
 		shcd, err := shcd.NewShcd(args[0])
 		if err != nil {
 			log.Fatal(err)
 		}
 		if createHMN {
-			err := createHMNSeed(shcd.Topology)
+			err := createHMNSeed(shcd)
 			if err != nil {
 				fmt.Printf("WARNING - Error creating hmn-connections: %+v", err)
 			}
@@ -193,21 +196,24 @@ func createSwitchSeed(topology []shcd.ID) error {
 		switchType := sw.GenerateSwitchType()
 		// The vendor just needs to be capitalized
 		switchVendor := strings.Title(sw.Vendor)
+		// Model does not need any extra manipulation, just put the string into place
+		switchModel := sw.Model
 		// Create a new Switch type and append it to the SwitchMetadata slice
 		sws = append(sws, shcd.Switch{
 			Xname: switchXname,
 			Type:  switchType,
 			Brand: switchVendor,
+			Model: switchModel,
 		})
 	}
 	// When writing to csv, the first row should be the headers
-	headers := []string{"Switch Xname", "Type", "Brand"}
+	headers := []string{"Switch Xname", "Type", "Brand", "Model"}
 	// Set up the records we need to write to the file
 	// To begin, this contains the headers
 	records := [][]string{headers}
 	// Then create a new slice with the three pieces of information needed
 	for _, sw := range sws {
-		records = append(records, []string{sw.Xname, sw.Type, sw.Brand})
+		records = append(records, []string{sw.Xname, sw.Type, sw.Brand, sw.Model})
 	}
 	// Create the file object
 	sm, err := os.Create(switchMetadata)
@@ -237,46 +243,77 @@ func createSwitchSeed(topology []shcd.ID) error {
 }
 
 // createHMNSeed creates hmn_connections.json using information from the shcd
-func createHMNSeed(topology []shcd.ID) error {
+func createHMNSeed(s *shcd.Shcd) error {
 	var hmn shcd.HMNConnections
-	for _, i := range topology {
-		fmt.Println(i.CommonName, "---->", i.CommonName)
+	for _, i := range s.Topology {
+		if i.Architecture == "river_bmc_leaf" && i.Type == "switch" {
+			// the leaf bmc is not needed in hmn_connections
+			continue
+		}
 		// instantiate a new HMNComponent
 		hmnConnection := shcd.HMNComponent{}
 		// This just aligns the names to better match existing hmn_connections.json's
 		// The SHCD and shcd.json all use different names, so why should csi be any different?
-		// nodeName := unNormalizeSemiStandardShcdNonName(topology[i].CommonName)
-		// Setting the source name, source rack, source location, is pretty straightforward here
+		// nodeName := unNormalizeSemiStandardShcdNonName(i.CommonName)
 		hmnConnection.Source = i.GenerateSourceName()
+		// Setting the source rack and location is more straightforward then the name
 		hmnConnection.SourceRack = i.Location.Rack
 		hmnConnection.SourceLocation = i.Location.Elevation
+
 		// Now it starts to get more complex.
-		// shcd.json has an array of ports that the device is connected to
-		// loop through the ports and find the destination id, which can be used
-		// to find the destination info
+		// the paddle/ccj file has an array of ports that the device is connected to
+		// loop through the ports and set the items needed for hmn_connections.json
 		for _, p := range i.Ports {
-			// get the id of the destination node, so it can be easily used an an index
-			// destID := p.DestNodeID
 			// Special to this hmn_connections.json file, we need this SubRack/dense node stuff
-			// if the node is a dense compute node--indicated by L or R in the location,
-			// we need to add the SourceSubLocation and SourceParent
-			// There should be a row in the shcd that has the SubRack name, which
-			// shares the same u location as the entries with the L or R in the location
-			if strings.HasSuffix(i.Location.Elevation, "L") || strings.HasSuffix(i.Location.Elevation, "R") {
-				// hmnConnection.SourceSubLocation = shcd[i].Location.Rack
-				hmnConnection.SourceParent = "FIXME INSERT SUBRACK HERE"
-				// FIXME: remove above and uncomment below when we have a way to get the subrack name
-				// hmnConnection.SourceParent = fmt.Sprint(shcd[destID].CommonName)
+			// if the node is a dense compute node--we need to add the SourceSubLocation and SourceParent
+			// the paddle schema includes this subrack
+			// it is limited to the compute nodes
+			if i.Architecture == "river_compute_node" || i.Model == "river_compute_node" {
+				// the cmc slot points at the subrack ID, which becomes the SourceParent
+				if p.Slot == "cmc" {
+					hmnConnection.SourceParent = i.Location.Parent
+				}
+				// hmn_connections.json is only concerned with the BMC connections
+				if p.Slot == "bmc" {
+					// this will need human intervention
+					hmnConnection.SourceSubLocation = "FIXME-L-or-R"
+					// the subrack also needs the destination rack, which will be the cmc-subrack ID
+					hmnConnection.DestinationRack = s.DestRack(p)
+				}
+			} else {
+				if i.Type == "node" || i.Architecture == "subrack" || i.Vendor == "subrack" {
+					// skip the subrack ID as it is not needed in hmn_connections.json
+					continue
+				}
+				hmnConnection.DestinationRack = s.DestRack(p)
 			}
-			// Now use the destID again to set the destination info
-			hmnConnection.DestinationRack = i.Location.Rack
-			hmnConnection.DestinationLocation = i.Location.Elevation
-			hmnConnection.DestinationPort = fmt.Sprint("j", p.DestPort)
+			// ncn-m001 is special and has a site connection
+			if i.CommonName == "ncn-m001" && i.Type == "server" {
+				hmnConnection.DestinationLocation = "SITE"
+				hmnConnection.DestinationRack = "SITE"
+			}
+			// as do the spines
+			if i.Architecture == "spine" && i.Type == "switch" {
+				hmnConnection.DestinationLocation = "SITE"
+				hmnConnection.DestinationRack = "SITE"
+			}
+			// hsn switch needs the rack as well
+			if i.Architecture == "slingshot_hsn_switch" && i.Type == "switch" {
+				hmnConnection.DestinationLocation = s.DestElevation(p)
+				hmnConnection.DestinationRack = s.DestRack(p)
+				hmnConnection.DestinationPort = fmt.Sprint(p.DestPort)
+			}
+			// hmn_connections.json is only concerned with the BMC connections
+			if p.Slot == "bmc" {
+				hmnConnection.DestinationLocation = s.DestElevation(p)
+				hmnConnection.DestinationPort = fmt.Sprint(p.DestPort)
+			}
 		}
 		// finally, append the created HMNComponent to the HMNConnections slice
 		// This slice will be what is written to the file as hmn_connections.json
 		hmn = append(hmn, hmnConnection)
 	}
+
 	// Indent the file for better human-readability
 	file, err := json.MarshalIndent(hmn, "", "    ")
 	if err != nil {

--- a/cmd/shcd_test.go
+++ b/cmd/shcd_test.go
@@ -49,7 +49,7 @@ func TestCreateHMNConnections(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 	// Create hmn_connections.json
-	err = createHMNSeed(shcd.Topology)
+	err = createHMNSeed(&shcd)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -313,9 +313,9 @@ func TestGenerateSourceName(t *testing.T) {
 			want:       "sw-hsn01",
 		},
 		{
-			desc:       "Common Name cn005 returns cn05",
+			desc:       "Common Name cn005 returns cn-05",
 			commonName: "cn005",
-			want:       "cn05",
+			want:       "cn-05",
 		},
 		{
 			desc:       "Common Name gateway001 returns gateway01",

--- a/testdata/expected/hmn_connections.json
+++ b/testdata/expected/hmn_connections.json
@@ -3,273 +3,218 @@
         "Source": "sw-cdu-002",
         "SourceRack": "cdu0",
         "SourceLocation": "su2",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "u1",
-        "DestinationPort": "j52"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "sw-cdu-001",
         "SourceRack": "cdu0",
         "SourceLocation": "u1",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j52"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-000",
         "SourceRack": "x1000",
         "SourceLocation": "c0",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j1"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-001",
         "SourceRack": "x1000",
         "SourceLocation": "c1",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j2"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-002",
         "SourceRack": "x1000",
         "SourceLocation": "c2",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j3"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-003",
         "SourceRack": "x1000",
         "SourceLocation": "c3",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j4"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-004",
         "SourceRack": "x1000",
         "SourceLocation": "c4",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j5"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-005",
         "SourceRack": "x1000",
         "SourceLocation": "c5",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j6"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-006",
         "SourceRack": "x1000",
         "SourceLocation": "c6",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j7"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cmm-x1000-007",
         "SourceRack": "x1000",
         "SourceLocation": "c7",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j8"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cec-x1000-000",
         "SourceRack": "x1000",
         "SourceLocation": "c6",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "u1",
-        "DestinationPort": "j48"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "cec-x1000-001",
         "SourceRack": "x1000",
         "SourceLocation": "c7",
-        "DestinationRack": "cdu0",
-        "DestinationLocation": "su2",
-        "DestinationPort": "j48"
+        "DestinationRack": "cdu0"
     },
     {
         "Source": "sw-spine-002",
         "SourceRack": "x3000",
         "SourceLocation": "u38",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u37",
-        "DestinationPort": "j32"
+        "DestinationRack": "SITE",
+        "DestinationLocation": "SITE"
     },
     {
         "Source": "sw-spine-001",
         "SourceRack": "x3000",
         "SourceLocation": "u37",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u38",
-        "DestinationPort": "j32"
+        "DestinationRack": "SITE",
+        "DestinationLocation": "SITE"
     },
     {
         "Source": "sw-leaf-003",
         "SourceRack": "x3000",
         "SourceLocation": "u36",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u35",
-        "DestinationPort": "j56"
+        "DestinationRack": "x3000"
     },
     {
         "Source": "sw-leaf-004",
         "SourceRack": "x3000",
         "SourceLocation": "u35",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u36",
-        "DestinationPort": "j56"
+        "DestinationRack": "x3000"
     },
     {
         "Source": "sw-leaf-001",
         "SourceRack": "x3000",
         "SourceLocation": "u34",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j56"
+        "DestinationRack": "x3000"
     },
     {
         "Source": "sw-leaf-002",
         "SourceRack": "x3000",
         "SourceLocation": "u33",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u34",
-        "DestinationPort": "j56"
-    },
-    {
-        "Source": "sw-leaf-bmc-002",
-        "SourceRack": "x3000",
-        "SourceLocation": "u32",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u36",
-        "DestinationPort": "j48"
-    },
-    {
-        "Source": "sw-leaf-bmc-001",
-        "SourceRack": "x3000",
-        "SourceLocation": "u31",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u34",
-        "DestinationPort": "j48"
+        "DestinationRack": "x3000"
     },
     {
         "Source": "uan02",
         "SourceRack": "x3000",
         "SourceLocation": "u16",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j13"
+        "DestinationLocation": "u31",
+        "DestinationPort": "41"
     },
     {
         "Source": "uan01",
         "SourceRack": "x3000",
         "SourceLocation": "u15",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j12"
+        "DestinationLocation": "u31",
+        "DestinationPort": "40"
     },
     {
         "Source": "sn03",
         "SourceRack": "x3000",
         "SourceLocation": "u10",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j6"
+        "DestinationLocation": "u32",
+        "DestinationPort": "38"
     },
     {
         "Source": "sn02",
         "SourceRack": "x3000",
         "SourceLocation": "u09",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u35",
-        "DestinationPort": "j4"
+        "DestinationLocation": "u31",
+        "DestinationPort": "39"
     },
     {
         "Source": "sn01",
         "SourceRack": "x3000",
         "SourceLocation": "u08",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u35",
-        "DestinationPort": "j3"
+        "DestinationLocation": "u31",
+        "DestinationPort": "38"
     },
     {
         "Source": "wn04",
         "SourceRack": "x3000",
         "SourceLocation": "u07",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u35",
-        "DestinationPort": "j2"
+        "DestinationLocation": "u32",
+        "DestinationPort": "37"
     },
     {
         "Source": "wn03",
         "SourceRack": "x3000",
         "SourceLocation": "u06",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j5"
+        "DestinationLocation": "u31",
+        "DestinationPort": "37"
     },
     {
         "Source": "wn02",
         "SourceRack": "x3000",
         "SourceLocation": "u05",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j4"
+        "DestinationLocation": "u31",
+        "DestinationPort": "36"
     },
     {
         "Source": "wn01",
         "SourceRack": "x3000",
         "SourceLocation": "u04",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j3"
+        "DestinationLocation": "u31",
+        "DestinationPort": "35"
     },
     {
         "Source": "mn03",
         "SourceRack": "x3000",
         "SourceLocation": "u03",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u35",
-        "DestinationPort": "j1"
+        "DestinationLocation": "u32",
+        "DestinationPort": "36"
     },
     {
         "Source": "mn02",
         "SourceRack": "x3000",
         "SourceLocation": "u02",
         "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j2"
+        "DestinationLocation": "u31",
+        "DestinationPort": "34"
     },
     {
         "Source": "mn01",
         "SourceRack": "x3000",
         "SourceLocation": "u01",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u33",
-        "DestinationPort": "j1"
+        "DestinationRack": "SITE",
+        "DestinationLocation": "SITE"
     },
     {
         "Source": "sw-edge-001",
         "SourceRack": "x3000",
         "SourceLocation": "u18",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u38",
-        "DestinationPort": "j29"
+        "DestinationRack": "x3000"
     },
     {
         "Source": "sw-edge-002",
         "SourceRack": "x3000",
         "SourceLocation": "u19",
-        "DestinationRack": "x3000",
-        "DestinationLocation": "u38",
-        "DestinationPort": "j28"
+        "DestinationRack": "x3000"
     },
     {
         "Source": "x3000p1",
@@ -277,7 +222,7 @@
         "SourceLocation": "p1",
         "DestinationRack": "x3000",
         "DestinationLocation": "u32",
-        "DestinationPort": "j48"
+        "DestinationPort": "48"
     },
     {
         "Source": "x3000p0",
@@ -285,7 +230,7 @@
         "SourceLocation": "p0",
         "DestinationRack": "x3000",
         "DestinationLocation": "u31",
-        "DestinationPort": "j48"
+        "DestinationPort": "48"
     },
     {
         "Source": "sw-hsn02",
@@ -293,7 +238,7 @@
         "SourceLocation": "u40",
         "DestinationRack": "x3000",
         "DestinationLocation": "u32",
-        "DestinationPort": "j47"
+        "DestinationPort": "47"
     },
     {
         "Source": "sw-hsn01",
@@ -301,6 +246,6 @@
         "SourceLocation": "u39",
         "DestinationRack": "x3000",
         "DestinationLocation": "u31",
-        "DestinationPort": "j47"
+        "DestinationPort": "47"
     }
 ]

--- a/testdata/expected/surtur_switch_metadata.csv
+++ b/testdata/expected/surtur_switch_metadata.csv
@@ -1,4 +1,4 @@
-Switch Xname,Type,Brand
-x3000c0h12s1,Spine,Aruba
-x3000c0h13s1,Spine,Aruba
-x3000c0w14,LeafBMC,Aruba
+Switch Xname,Type,Brand,Model
+x3000c0h12s1,Spine,Aruba,8325_JL625A
+x3000c0h13s1,Spine,Aruba,8325_JL625A
+x3000c0w14,LeafBMC,Aruba,6300M_JL762A

--- a/testdata/expected/switch_metadata.csv
+++ b/testdata/expected/switch_metadata.csv
@@ -1,13 +1,13 @@
-Switch Xname,Type,Brand
-d0w1,CDU,Aruba
-d0w2,CDU,Aruba
-x3000c0h18s1,Edge,None
-x3000c0h19s1,Edge,None
-x3000c0h33s1,Leaf,Aruba
-x3000c0h34s1,Leaf,Aruba
-x3000c0h35s1,Leaf,Aruba
-x3000c0h36s1,Leaf,Aruba
-x3000c0h37s1,Spine,Aruba
-x3000c0h38s1,Spine,Aruba
-x3000c0w31,LeafBMC,Aruba
-x3000c0w32,LeafBMC,Aruba
+Switch Xname,Type,Brand,Model
+d0w1,CDU,Aruba,8360_JL706A
+d0w2,CDU,Aruba,8360_JL706A
+x3000c0h18s1,Edge,None,customer_edge_router
+x3000c0h19s1,Edge,None,customer_edge_router
+x3000c0h33s1,Leaf,Aruba,8325_JL625A
+x3000c0h34s1,Leaf,Aruba,8325_JL625A
+x3000c0h35s1,Leaf,Aruba,8325_JL625A
+x3000c0h36s1,Leaf,Aruba,8325_JL625A
+x3000c0h37s1,Spine,Aruba,8325_JL627A
+x3000c0h38s1,Spine,Aruba,8325_JL627A
+x3000c0w31,LeafBMC,Aruba,6300M_JL762A
+x3000c0w32,LeafBMC,Aruba,6300M_JL762A


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-5040.  I used the ccj.json from that ticket (that failed to generate good data previously) and used it to validate the code in the PR is much closer to reality
- Relates to: CASMINST-5089

This PR fixes a few things:

- `csi` would ignore the flags passed to `config shcd` and just generate every seed file.  It no longer does that, so users can generate a specific seed file if they desire
- `csi` did not generate correct data for the seed files.  This was mainly due to the schema changes `canu` introduced, and this code was never updated to work with it.  Specifically, the dense node/subrack capabilities added to canu caused the existing code to provide inaccurate data when creating the seed files.  the data it generates is more accurate, but there are still a few placeholder values that the user must enter.  
- the subrack keys are now `omitempty` so there is no empty value entries adding confusion to the resulting files
- the `switch_metadata.csv` has a new column, `Vendor`, which is now populated in `switch_metadata.csv`

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->

Subsequent runs of `config shcd` always overwrite the files (existing behavior).
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

Low.  This feature was stripped from 1.3, but is still being used on projects like CVT and it still provides a use to save time when creating these files manually as it does a large chunk of the work, but still requires some human intervention to replace some `FIXME` placeholders.

-->
