### PR TITLE
CASMINST-5255 - "csi handoff bss-metadata" panics if supplied password is incorrect

### DIFF
--- a/cmd/handoff-bss-metadata.go
+++ b/cmd/handoff-bss-metadata.go
@@ -279,7 +279,8 @@ func getSSHClientForHostname(hostname string) (sshClient *ssh.Client) {
 
 	sshClient, err = ssh.Dial("tcp", hostname+":22", sshConfig)
 	if err != nil {
-		log.Panic(err)
+		log.Printf("Unable to connect to %s. Was the supplied password correct?", hostname)
+		log.Fatal("Error detail: ", err)
 	}
 
 	return


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMINST-5255](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5255)

#### Issue Type

- Bugfix Pull Request

The `csi handoff bss-metadata` command panics if the supplied SSH password is incorrect resulting in output that is confusing to the user.

This PR causes the SSH failure to exit a little more gracefully with output that is helpful to the user rather than panicking and dumping a stack trace.

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

Old output
```
root@starlord-ncn-m001-pit 2022-08-18 06:33:56 /var/www/ephemeral/prep/admin # csi handoff bss-metadata --data-file "${PITDATA}/configs/data.json" || echo "ERROR: csi handoff bss-metadata failed"
2022/08/18 06:33:58 Getting management NCNs from SLS...
2022/08/18 06:33:58 Done getting management NCNs from SLS.
2022/08/18 06:33:58 Building BSS metadata for NCNs...
Enter root password for NCNs:
2022/08/18 06:34:02 Connecting to ncn-s001...
2022/08/18 06:34:05 ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
panic: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain

goroutine 1 [running]:
log.Panic(\{0xc00079f050?, 0xc0009ae1d8?, 0xc00043b0c0?})
        /usr/local/go/src/log/log.go:385 +0x65
github.com/Cray-HPE/cray-site-init/cmd.getSSHClientForHostname(\{0xc0009ae1d8, 0x8})
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/cmd/handoff-bss-metadata.go:204 +0xf7
github.com/Cray-HPE/cray-site-init/cmd.getBSSEntryForNCN(\{{0xc0009ae190, 0xc}, \{0x0, 0x0, 0x0}, \{0xc0009ae1a0, 0xe}, \{0xc0009ae1b0, 0xd}, \{0xc0009ae188, ...}, ...})
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/cmd/handoff-bss-metadata.go:293 +0xd3
github.com/Cray-HPE/cray-site-init/cmd.populateNCNMetadata()
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/cmd/handoff-bss-metadata.go:492 +0x938
github.com/Cray-HPE/cray-site-init/cmd.glob..func10(0x3052760?, \{0x1d688c0?, 0x2?, 0x2?})
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/cmd/handoff-bss-metadata.go:110 +0x24d
github.com/spf13/cobra.(*Command).execute(0x3052760, \{0xc0000f57e0, 0x2, 0x2})
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/vendor/github.com/spf13/cobra/command.go:876 +0x67b
github.com/spf13/cobra.(*Command).ExecuteC(0x30551e0)
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/vendor/github.com/spf13/cobra/command.go:990 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/vendor/github.com/spf13/cobra/command.go:918
github.com/Cray-HPE/cray-site-init/cmd.Execute()
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/cmd/root.go:62 +0x25
main.main()
        /home/jenkins/workspace/Cray-HPE_cray-site-init_v1.24.2/dist/rpmbuild/BUILD/cray-site-init-1.24.2/main.go:16 +0xca
ERROR: csi handoff bss-metadata failed
root@starlord-ncn-m001-pit 2022-08-18 06:34:05 /var/www/ephemeral/prep/admin #
```
New output
```
ncn-m001:~/cspiller/CASMINST-5255 # ./csi handoff bss-metadata --data-file /root/cspiller/CASMINST-5255/data.json
2022/10/31 10:37:54 Getting management NCNs from SLS...
2022/10/31 10:37:54 Done getting management NCNs from SLS.
2022/10/31 10:37:54 Building BSS metadata for NCNs...
Enter root password for NCNs:
2022/10/31 10:37:58 Connecting to ncn-s002...
2022/10/31 10:38:00 Unable to connect to ncn-s002. Was the supplied password correct?
2022/10/31 10:38:00 Error detail: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none password], no supported methods remain
```
 
### Idempotency

 
### Risks and Mitigations
 

