### PR TITLE
CASMPET-6145: Add cilium-operator-replicas, k8s-primary-cni, and kube-proxy-replacement

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -752,7 +752,7 @@ func writeOutput(v *viper.Viper, shastaNetworks map[string]*csi.IPV4Network, sls
 func validateFlags() []string {
 	var errors []string
 	v := viper.GetViper()
-	expectedCSMVersion := "1.3"
+	expectedCSMVersion := "1.4"
 
 	var requiredFlags = []string{
 		"system-name",
@@ -828,6 +828,44 @@ func validateFlags() []string {
 	}
 	if !validBican {
 		errors = append(errors, fmt.Sprintf("%v must be set to CAN, CHN or HSN. (HSN requires NAT device)", bicanFlag))
+	}
+
+	if v.IsSet("cilium-operator-replicas") {
+		validFlag := false
+		var cor int
+		cor = v.GetInt("cilium-operator-replicas")
+		if cor > 0 {
+			validFlag = true
+		}
+		if !validFlag {
+			errors = append(errors, fmt.Sprintf("cilium-operator-replicas must be an integer > 0"))
+		}
+	}
+
+	if v.IsSet("kube-proxy-replacement") {
+		validFlag := false
+		for _, value := range [3]string{"strict", "partial", "disabled"} {
+			if v.GetString("kube-proxy-replacement") == value {
+				validFlag = true
+				break
+			}
+		}
+		if !validFlag {
+			errors = append(errors, fmt.Sprintf("kube-proxy-replacement must be set to strict, partial, or disabled"))
+		}
+	}
+
+	if v.IsSet("k8s-primary-cni") {
+		validFlag := false
+		for _, value := range [3]string{"weave", "cilium"} {
+			if v.GetString("k8s-primary-cni") == value {
+				validFlag = true
+				break
+			}
+		}
+		if !validFlag {
+			errors = append(errors, fmt.Sprintf("k8s-primary-cni must be set to weave or cilium"))
+		}
 	}
 
 	return errors

--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -104,11 +104,14 @@ type BaseCampGlobals struct {
 	// CanGateway  string `json:can-gw`   // dnsmasq should provide this
 
 	// Kubernetes Installation Globals
-	KubernetesVIP          string `json:"kubernetes-virtual-ip"`
-	KubernetesMaxPods      string `json:"kubernetes-max-pods-per-node"`
-	KubernetesPodCIDR      string `json:"kubernetes-pods-cidr"`     // "10.32.0.0/12"
-	KubernetesServicesCIDR string `json:"kubernetes-services-cidr"` // "10.16.0.0/12"
-	KubernetesWeaveMTU     string `json:"kubernetes-weave-mtu"`     // 1376
+	KubernetesVIP              string `json:"kubernetes-virtual-ip"`
+	KubernetesMaxPods          string `json:"kubernetes-max-pods-per-node"`
+	KubernetesPodCIDR          string `json:"kubernetes-pods-cidr"`     // "10.32.0.0/12"
+	KubernetesServicesCIDR     string `json:"kubernetes-services-cidr"` // "10.16.0.0/12"
+	KubernetesWeaveMTU         string `json:"kubernetes-weave-mtu"`     // 1376
+	KubernetesCiliumOpReplicas string `json:"cilium-operator-replicas"` // 1
+	KubernetesPrimaryCNI       string `json:"k8s-primary-cni"`          // weave
+	KubernetesKubeProxyReplace string `json:"kube-proxy-replacement"`   // strict
 
 	NumStorageNodes int `json:"num_storage_nodes"`
 }
@@ -161,13 +164,16 @@ var basecampGlobalString = `{
 	"kubernetes-pods-cidr": "10.32.0.0/12",
 	"kubernetes-services-cidr": "10.16.0.0/12",
 	"kubernetes-weave-mtu": "1376",
+	"cilium-operator-replicas": "1",
+	"k8s-primary-cni": "weave",
+	"kube-proxy-replacement": "strict",
 	"rgw-virtual-ip": "~FIXME~ e.g. 10.252.2.100",
 	"wipe-ceph-osds": "yes",
 	"system-name": "~FIXME~",
 	"site-domain": "~FIXME~",
 	"internal-domain": "~FIXME~",
 	"k8s-api-auditing-enabled": "~FIXME~",
-    "ncn-mgmt-node-auditing-enabled": "~FIXME~"
+	"ncn-mgmt-node-auditing-enabled": "~FIXME~"
 	}`
 
 // BasecampHostRecord is what we need for passing stuff to /etc/hosts


### PR DESCRIPTION
### Summary and Scope

- Fixes: [CASMPET-6145](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6145)
- Relates to: MTL-1971

#### Issue Type

- RFE Pull Request

This adds cilium-operator-replicas, k8s-primary-cni, and kube-proxy-replacement the basecamp output.
These are optional and will default if not specified.   There is validation for each of these if they are specified.

This also sets the expected CSM version to 1.4.

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this locally
 
Tested this with various valid and invalid combinations of the three additional fields.

### Idempotency
 
Ran csi config init multiple times in a row.
 
### Risks and Mitigations
 
Low risk.   The default for k8s-primary-cni is still set to weave.   The other two will be ignored unless k8s-primary-cni is set to cilium.