### PR TITLE
MTL-1708 Build & Publish SP4 RPMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Lint
       run: |

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -46,41 +46,77 @@ pipeline {
 
     stages {
 
-        stage('Prepare: RPMs') {
-            agent {
-                docker {
-                    label 'docker'
-                    reuseNode true
-                    image "${goImage}:${env.GO_VERSION}"
-                }
-            }
-            steps {
-                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                sh "make rpm_prepare"
-                sh "git update-index --assume-unchanged ${env.NAME}.spec"
-            }
-        }
+        stage('Build & Publish') {
 
-        stage('Build: RPMs') {
-            agent {
-                docker {
-                    label 'docker'
-                    reuseNode true
-                    image "${goImage}:${env.GO_VERSION}"
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
+            matrix {
 
-        stage('Publish: RPMs') {
-            steps {
-                script {
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp3", arch: "x86_64", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp2", arch: "src", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: isStable)
+                agent {
+                    node {
+                        label "metal-gcp-builder"
+                        customWorkspace "${env.WORKSPACE}/${sleVersion}/${env.GO_VERSION}"
+                    }
+                }
+
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
+                }
+
+                stages {
+
+                    stage('Prepare: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${goImage}:${env.GO_VERSION}-SLES${sleVersion}"
+                            }
+                        }
+                        steps {
+                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                            sh "make rpm_prepare"
+                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                        }
+                    }
+
+                    stage('Build: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${goImage}:${env.GO_VERSION}-SLES${sleVersion}"
+                            }
+                        }
+                        steps {
+                            sh "make rpm"
+                        }
+                    }
+
+                    stage('Publish: RPMs') {
+                        steps {
+                            script {
+                                sles_version_parts = "${sleVersion}".tokenize('.')
+                                sles_major = "${sles_version_parts[0]}"
+                                sles_minor = "${sles_version_parts[1]}"
+                                publishCsmRpms(
+                                        arch: "x86_64",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "src",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/go.mod
+++ b/go.mod
@@ -133,4 +133,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-go 1.18
+go 1.19


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Continue to build and publish SP3 RPMs while publishing SP4 RPMs.
Also upgrade to Go 1.19 since.

The SLES 15SP3 build creates an RPM with SP3 metadata and publishes it to `sle-15sp3`:

```bash
Name        : cray-site-init
Version     : 1.29.0~1~g50e3dc0b
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 65553484
License     : MIT License
Signature   : (none)
Source RPM  : cray-site-init-1.29.0~1~g50e3dc0b-1.src.rpm
Build Date  : Fri 02 Dec 2022 08:27:02 PM UTC
Build Host  : 7a5549c14ea6
Relocations : (not relocatable)
Vendor      : Cray Inc.
URL         : https://github.com/Cray-HPE/cray-site-init.git
Summary     : HPCaaS configuration and deployment tool for bare-metal or reinstallations
Description :
Git Repository: cray-site-init
Git Branch: MTL-1708-SP4
Git Commit Revision: 50e3dc0b
Git Commit Timestamp: Fri Dec 2 14:23:45 2022 -0600

Installs the Cray Site Initiator GoLang binary onto a Linux system.
Distribution: SUSE Linux Enterprise Server 15 SP3
```

The SLES 15SP4 build creates an RPM with SP4 metadata, and publishes it to `sle-15sp4`:

```bash
Name        : cray-site-init
Version     : 1.29.0~1~g50e3dc0b
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 65553340
License     : MIT License
Signature   : (none)
Source RPM  : cray-site-init-1.29.0~1~g50e3dc0b-1.src.rpm
Build Date  : Fri 02 Dec 2022 08:27:11 PM UTC
Build Host  : e3312d9f506f
Relocations : (not relocatable)
Packager    : https://www.suse.com/
Vendor      : Cray Inc.
URL         : https://github.com/Cray-HPE/cray-site-init.git
Summary     : HPCaaS configuration and deployment tool for bare-metal or reinstallations
Description :
Git Repository: cray-site-init
Git Branch: MTL-1708-SP4
Git Commit Revision: 50e3dc0b
Git Commit Timestamp: Fri Dec 2 14:23:45 2022 -0600

Installs the Cray Site Initiator GoLang binary onto a Linux system.
Distribution: SUSE Linux Enterprise Server 15 SP4
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
