### PR TITLE
MTL-2081 Prevent `empty` from clobbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage*
 build/
 !cmd/embeded-files/*
 dist/
+system_config.*

--- a/cmd/empty.go
+++ b/cmd/empty.go
@@ -46,7 +46,10 @@ var emptyCmd = &cobra.Command{
 		v.BindPFlags(initCmd.Flags())
 		v.SetConfigType("yaml")
 		v.Set("VersionInfo", version.Get())
-		v.WriteConfigAs("system_config.yaml")
+		err = v.SafeWriteConfigAs("system_config.yaml")
+		if err != nil {
+			log.Fatal(err)
+		}
 		log.Printf("Empty config file written to: %s/system_config.yaml\n", path)
 	},
 }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2081
- Relates to: https://github.com/Cray-HPE/cray-site-init/pull/294

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
If a `system_config.yaml` file already exists, do not clobber it when invoking `csi config init empty`.

```bash
[808]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/cray-site-init> ./bin/csi config init empty
2023/03/08 13:35:18 Using config file: /Users/rusty/gitstuffs/cray-shasta/cray-site-init/system_config.yaml
2023/03/08 13:35:18 Config File "system_config.yaml" Already Exists
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
