### PR TITLE
MTL-2000 Needs top-level `Zypper` key

### DIFF
--- a/cmd/patch/patch-packages.go
+++ b/cmd/patch/patch-packages.go
@@ -47,9 +47,20 @@ type Repo struct {
 // Packages is a list of packages to install on the client node.
 type Packages []string
 
+// Zypper is a map for Zypper cloud-init data.
+type Zypper struct {
+	Repos []Repo `json:"repos"`
+}
+
+// ConfigFileData matches the current “cloud-init“ file in the CSM tarball.
+type ConfigFileData struct {
+	Repos    []Repo   `json:"repos"`
+	Packages Packages `json:"packages"`
+}
+
 // UserData is the cloud-init structure/representation of the new data.
 type UserData struct {
-	Repos    []Repo   `json:"repos"`
+	Zypper   Zypper   `json:"zypper"`
 	Packages Packages `json:"packages"`
 }
 
@@ -106,18 +117,24 @@ func init() {
 	patchPackages.MarkFlagRequired("config-file")
 }
 
-// loadPackagesConfig reads the a configFile, returning its contents as unmarshalled YAML.
+// loadPackagesConfig reads a configFile, returning its contents as unmarshalled YAML.
 func loadPackagesConfig(filePath string) (UserData, error) {
 
+	var configData ConfigFileData
 	var data UserData
 	config, err := os.ReadFile(filePath)
 	if err != nil {
 		return data, err
 	}
 
-	if err := yaml.Unmarshal(config, &data); err != nil {
+	if err := yaml.Unmarshal(config, &configData); err != nil {
 		return data, err
 	}
+
+	data.Zypper = Zypper{
+		Repos: configData.Repos,
+	}
+	data.Packages = configData.Packages
 
 	return data, err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,5 +115,5 @@ func init() {
 	// Add a global '--config' option, so someone can pass in their own
 	// config file if desired, overriding the one in the current dir when
 	// we initialize this cobra program
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "CSI config file")
 }

--- a/pkg/pit/dnsmasq.go
+++ b/pkg/pit/dnsmasq.go
@@ -91,6 +91,8 @@ domain=mtl,{{.CIDR.IP}},{{.DHCPEnd}},local
 dhcp-option=interface:bond0,option:domain-search,mtl
 interface=bond0
 interface-name=pit.mtl,bond0
+cname=packages.mtl,pit.mtl
+cname=registry.mtl,pit.mtl
 # This needs to point to the liveCD IP for provisioning in bare-metal environments.
 dhcp-option=interface:bond0,option:dns-server,{{.PITServer}}
 dhcp-option=interface:bond0,option:ntp-server,{{.PITServer}}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #324 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `repos` key is actually nested under `zypper`, cloud-init specifically looks for the parent key `zypper` for determining to run the `zypper_add_repos` module.

What the JSON looked like before when patched:
```json
      "packages": [
        "cani",
        "canu",
        "cray-cmstools-crayctldeploy",
        "csm-testing",
        "goss-servers",
        "iuf-cli",
        "libcsm",
        "platform-utils"
      ],
      "runcmd": [
        "/srv/cray/scripts/metal/net-init.sh",
        "/srv/cray/scripts/common/update_ca_certs.py",
        "/srv/cray/scripts/metal/install.sh",
        "/srv/cray/scripts/common/pre-load-images.sh",
        "/srv/cray/scripts/common/storage-ceph-cloudinit.sh",
        "touch /etc/cloud/cloud-init.disabled"
      ],
      "timezone": "UTC",
      "write_files": [
        {
          "content": "10.106.0.0/22 10.252.0.1 - bond0.nmn0\n10.1.0.0/16 10.252.0.1 - bond0.nmn0\n10.92.100.0/24 10.252.0.1 - bond0.nmn0\n",
          "owner": "root:root",
          "path": "/etc/sysconfig/network/ifroute-bond0.nmn0",
          "permissions": "0644"
        },
        {
          "content": "10.107.0.0/22 10.254.0.1 - bond0.hmn0\n10.94.100.0/24 10.254.0.1 - bond0.hmn0\n",
          "owner": "root:root",
          "path": "/etc/sysconfig/network/ifroute-bond0.hmn0",
          "permissions": "0644"
        }
      ],
      "repos": [
        {
          "autorefresh": 1,
          "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
          "enabled": 1,
          "gpgcheck": 0,
          "id": "csm-noos",
          "name": "csm-noos"
        },
        {
          "autorefresh": 1,
          "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
          "enabled": 1,
          "gpgcheck": 0,
          "id": "csm-sle",
          "name": "csm-sle-${releasever_major}sp${releasever_minor}"
        }
      ]
    }
```

What the JSON looks like now:
```json
      "packages": [
        "cani",
        "canu",
        "cray-cmstools-crayctldeploy",
        "csm-testing",
        "goss-servers",
        "iuf-cli",
        "libcsm",
        "platform-utils"
      ],
      "runcmd": [
        "/srv/cray/scripts/metal/net-init.sh",
        "/srv/cray/scripts/common/update_ca_certs.py",
        "/srv/cray/scripts/metal/install.sh",
        "/srv/cray/scripts/common/pre-load-images.sh",
        "/srv/cray/scripts/common/storage-ceph-cloudinit.sh",
        "touch /etc/cloud/cloud-init.disabled"
      ],
      "timezone": "UTC",
      "write_files": [
        {
          "content": "10.106.0.0/22 10.252.0.1 - bond0.nmn0\n10.1.0.0/16 10.252.0.1 - bond0.nmn0\n10.92.100.0/24 10.252.0.1 - bond0.nmn0\n",
          "owner": "root:root",
          "path": "/etc/sysconfig/network/ifroute-bond0.nmn0",
          "permissions": "0644"
        },
        {
          "content": "10.107.0.0/22 10.254.0.1 - bond0.hmn0\n10.94.100.0/24 10.254.0.1 - bond0.hmn0\n",
          "owner": "root:root",
          "path": "/etc/sysconfig/network/ifroute-bond0.hmn0",
          "permissions": "0644"
        }
      ],
      "zypper": {
        "repos": [
          {
            "autorefresh": 1,
            "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
            "enabled": 1,
            "gpgcheck": 0,
            "id": "csm-noos",
            "name": "csm-noos"
          },
          {
            "autorefresh": 1,
            "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
            "enabled": 1,
            "gpgcheck": 0,
            "id": "csm-sle",
            "name": "csm-sle-${releasever_major}sp${releasever_minor}"
          }
        ]
      }
    }
```

I confirmed that the cloud-init module added repositories after using the bugfix to patch `data.json`.

I'm not sure why this was missed originally, but for cloud-init 21.4 and 23.2 the `zypper` key needs to be defined. I think I must have used that key during my manual tests.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
