### PR TITLE
MTL-2000 Handle both formats

### DIFF
--- a/cmd/patch/patch-packages.go
+++ b/cmd/patch/patch-packages.go
@@ -127,15 +127,19 @@ func loadPackagesConfig(filePath string) (UserData, error) {
 		return data, err
 	}
 
-	if err := yaml.Unmarshal(config, &configData); err != nil {
+	// Handle config files with or without the ``zypper`` root key.
+	if err := yaml.Unmarshal(config, &data); err != nil {
 		return data, err
 	}
-
-	data.Zypper = Zypper{
-		Repos: configData.Repos,
+	if data.Zypper.Repos == nil {
+		if err := yaml.Unmarshal(config, &configData); err != nil {
+			return data, err
+		}
+		data.Zypper = Zypper{
+			Repos: configData.Repos,
+		}
+		data.Packages = configData.Packages
 	}
-	data.Packages = configData.Packages
-
 	return data, err
 }
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #333 

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Handle `cloud-init.yaml` with or without a root `zypper` key.

Tested with both formats, and both produced valid `data.json` with the `zypper` root key present.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
