### PR TITLE
CASMPET-6782 Add `packages.internal`

### DIFF
--- a/pkg/csi/defaults.go
+++ b/pkg/csi/defaults.go
@@ -415,7 +415,7 @@ type PinnedReservation struct {
 // *** *** *** To anyone editing this code in the future, PLEASE DON'T MAKE IT BETTER *** *** ***
 // *** *** *** This code is written to be thrown away with a fully dynamic ip addressing scheme *** *** ***
 var PinnedMetalLBReservations = map[string]PinnedReservation{
-	"istio-ingressgateway":       {71, strings.Split("api-gw-service api-gw-service-nmn.local packages registry spire.local api_gw_service registry.local packages packages.local spire", " ")},
+	"istio-ingressgateway":       {71, strings.Split("api-gw-service api-gw-service-nmn.local packages registry spire.local api_gw_service registry.local packages packages.local packages.internal spire", " ")},
 	"istio-ingressgateway-local": {81, []string{"api-gw-service.local"}},
 	"rsyslog-aggregator":         {72, []string{"rsyslog-agg-service"}},
 	"cray-tftp":                  {60, []string{"tftp-service"}},

--- a/pkg/pit/dnsmasq.go
+++ b/pkg/pit/dnsmasq.go
@@ -111,6 +111,7 @@ domain=nmn,{{.CIDR.IP}},{{.DHCPEnd}},local
 dhcp-option=interface:bond0.nmn0,option:domain-search,nmn
 interface=bond0.nmn0
 cname=packages.nmn,pit.nmn
+cname=packages.internal,pit.nmn
 cname=registry.nmn,pit.nmn
 # This needs to point to the liveCD IP for provisioning in bare-metal environments.
 dhcp-option=interface:bond0.nmn0,option:dns-server,{{.PITServer}}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: CASMPET-6782

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Adds a `packages.internal` alias for `pit.nmn`.
This alias will work in conjunction with a new alias in unbound and powerDNS for handline .internal queries.
During bootstrap (PIT) this'll resolve to nexus, and once the PIT is gone it'll resolve to k8s nexus.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
