### PR TITLE
MTL-2000 `packages.local` cname

### DIFF
--- a/pkg/pit/dnsmasq.go
+++ b/pkg/pit/dnsmasq.go
@@ -110,6 +110,7 @@ interface-name=pit.nmn,bond0.nmn0
 domain=nmn,{{.CIDR.IP}},{{.DHCPEnd}},local
 dhcp-option=interface:bond0.nmn0,option:domain-search,nmn
 interface=bond0.nmn0
+cname=packages.local,pit.nmn
 cname=packages.nmn,pit.nmn
 cname=registry.nmn,pit.nmn
 # This needs to point to the liveCD IP for provisioning in bare-metal environments.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-2000

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Adds `packages.local` as a CNAME to `packages.nmn`. This will trump `statics.conf`, causing `packages.local` to resolve to the PIT nexus while DNSMasq is running.
`statics.conf` must remain the same for CSM handoff to function properly, for unbound and istio to properly setup `packages.local`.

This is compatible with the MTL-2000 cloud-init code, this new CNAME will allow `packages.local` to correctly resolve to PIT nexus during bootstrap. Then, during the csm install, when DNSMasq is shutdown `packages.local` will begin resolving to k8s nexus.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
