### PR TITLE
CASMTRIAGE-6178 Cloud-init Zypper Repos and Packages Fix

### DIFF
--- a/cmd/patch/patch-packages.go
+++ b/cmd/patch/patch-packages.go
@@ -36,12 +36,13 @@ import (
 
 // Repo is a list of repositories to add to the client node.
 type Repo struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Baseurl     string `json:"baseurl"`
-	Enabled     int    `json:"enabled"`
-	Autorefresh int    `json:"autorefresh"`
-	Gpgcheck    int    `json:"gpgcheck"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Baseurl      string `json:"baseurl"`
+	Enabled      int    `json:"enabled"`
+	Autorefresh  int    `json:"autorefresh"`
+	Gpgcheck     int    `json:"gpgcheck"`
+	RepoGpgcheck int    `json:"repo_gpgcheck"`
 }
 
 // Packages is a list of packages to install on the client node.

--- a/pkg/pit/dnsmasq.go
+++ b/pkg/pit/dnsmasq.go
@@ -91,6 +91,7 @@ domain=mtl,{{.CIDR.IP}},{{.DHCPEnd}},local
 dhcp-option=interface:bond0,option:domain-search,mtl
 interface=bond0
 interface-name=pit.mtl,bond0
+cname=packages.local,pit.mtl
 cname=packages.mtl,pit.mtl
 cname=registry.mtl,pit.mtl
 # This needs to point to the liveCD IP for provisioning in bare-metal environments.
@@ -110,7 +111,6 @@ interface-name=pit.nmn,bond0.nmn0
 domain=nmn,{{.CIDR.IP}},{{.DHCPEnd}},local
 dhcp-option=interface:bond0.nmn0,option:domain-search,nmn
 interface=bond0.nmn0
-cname=packages.local,pit.nmn
 cname=packages.nmn,pit.nmn
 cname=registry.nmn,pit.nmn
 # This needs to point to the liveCD IP for provisioning in bare-metal environments.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-6178
- Relates to: MTL-2000

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

This resolves two issues.

##### First Issue - CASMTRIAGE-6178

###### Problem

The URLs used are not resolving properly during bootstrap due to `packages.local` existing only on the NMN. When the node starts up, it initially only has DNS for the MTL network. The MTL network is unaware of any `.nmn` search domains, and fails to resolve `packages.local`. The following error is observed:

```bash
Retrieving repository 'csm-noos' metadata [.error]
Repository 'csm-noos' is invalid.
[csm-noos|https://packages.local/repository/csm-noos?ssl_verify=no] Valid metadata not found at specified URL
History:
 - [|] Error trying to read from 'https://packages.local/repository/csm-noos?ssl_verify=no'
 - Timeout exceeded when accessing 'https://packages.local/repository/csm-noos/content?ssl_verify=no'.
Please check if the URIs defined for this repository are pointing to a valid repository.
Skipping repository 'csm-noos' because of the above error.
Retrieving repository 'csm-sle-15sp5' metadata [.error]
Repository 'csm-sle-15sp5' is invalid.
[csm-sle|https://packages.local/repository/csm-sle-15sp5?ssl_verify=no] Valid metadata not found at specified URL
History:
 - [|] Error trying to read from 'https://packages.local/repository/csm-sle-15sp5?ssl_verify=no'
 - Timeout exceeded when accessing 'https://packages.local/repository/csm-sle-15sp5/content?ssl_verify=no'.
Please check if the URIs defined for this repository are pointing to a valid repository.
Skipping repository 'csm-sle-15sp5' because of the above error.
Could not refresh the repositories because of errors.
2023-10-19 20:30:21,023 - util.py[WARNING]: Package update failed
Retrieving repository 'csm-noos' metadata [.error]
Repository 'csm-noos' is invalid.
[csm-noos|https://packages.local/repository/csm-noos?ssl_verify=no] Valid metadata not found at specified URL
History:
 - [|] Error trying to read from 'https://packages.local/repository/csm-noos?ssl_verify=no'
 - Timeout exceeded when accessing 'https://packages.local/repository/csm-noos/content?ssl_verify=no'.
Please check if the URIs defined for this repository are pointing to a valid repository.
Warning: Skipping repository 'csm-noos' because of the above error.
Retrieving repository 'csm-sle-15sp5' metadata [.error]
Repository 'csm-sle-15sp5' is invalid.
[csm-sle|https://packages.local/repository/csm-sle-15sp5?ssl_verify=no] Valid metadata not found at specified URL
History:
 - [|] Error trying to read from 'https://packages.local/repository/csm-sle-15sp5?ssl_verify=no'
 - Timeout exceeded when accessing 'https://packages.local/repository/csm-sle-15sp5/content?ssl_verify=no'.
Please check if the URIs defined for this repository are pointing to a valid repository.
```

NOTE: Since `autorefresh: 1` is set, the repositories refresh _twice_ because of the failure. The `package_update_upgrade_install` refreshes the repositories again because they still do not have any local cache because the `zypper_add_repo` module failed to refresh.

###### Solution

Move `packages.local` CNAME definition to the MTL network as a CNAME for `pit.mtl`.

The CNAME can not exist more than once, it can only be defined in one or the other network.

##### Second Issue - Unsigned Repos

###### Problem

After resolving the first issue, the following error message occured on a fresh deployment:

```bash
Retrieving repository 'csm-noos' metadata [...
Warning: File 'repomd.xml' from repository 'csm-noos' is unsigned.
    Note: Signing data enables the recipient to verify that no modifications occurred after the data
    were signed. Accepting data with no, wrong or unknown signature can lead to a corrupted system
    and in extreme cases even to a system compromise.
    Note: File 'repomd.xml' is the repositories master index file. It ensures the integrity of the
    whole repo.
    Warning: We can't verify that no one meddled with this file, so it might not be trustworthy
    anymore! You should not continue unless you know it's safe.
File 'repomd.xml' from repository 'csm-noos' is unsigned, continue? [yes/no] (no): no
error]
Repository 'csm-noos' is invalid.
[csm-noos|https://packages.local/repository/csm-noos?ssl_verify=no] Valid metadata not found at specified URL
History:
 - Signature verification failed for repomd.xml
 - Can't provide /repodata/repomd.xml
Please check if the URIs defined for this repository are pointing to a valid repository.
Skipping repository 'csm-noos' because of the above error.
Retrieving repository 'csm-sle-15sp5' metadata [..
Warning: File 'repomd.xml' from repository 'csm-sle-15sp5' is unsigned.
    Note: Signing data enables the recipient to verify that no modifications occurred after the data
    were signed. Accepting data with no, wrong or unknown signature can lead to a corrupted system
    and in extreme cases even to a system compromise.
    Note: File 'repomd.xml' is the repositories master index file. It ensures the integrity of the
    whole repo.
    Warning: We can't verify that no one meddled with this file, so it might not be trustworthy
    anymore! You should not continue unless you know it's safe.
File 'repomd.xml' from repository 'csm-sle-15sp5' is unsigned, continue? [yes/no] (no): no
error]
Repository 'csm-sle-15sp5' is invalid.
```

The repositories are supposed to be configured to allow them to be unsigned after these PRs added the `repo_gpgcheck: 0` key-value pair to the `cloud-init.yaml` file:

- https://github.com/Cray-HPE/csm/pull/2940
- https://github.com/Cray-HPE/csm/pull/2941

However, the new key was not appearing in the `data.json` file following `csi patch packages`.

###### Solution

An update to cray-site-init was neglected during CSM#2940 and CSM#2941, the structure for unmarshaling the `cloud-init.yaml` was not made aware of the `repo_gpgcheck` key.

After adding `repo_gpgcheck` to the `Repo` struct in `cmd/patch/patch-packages.go`, a successful deployment was observed.

```bash
Retrieving repository 'csm-noos' metadata [...done]
Building repository 'csm-noos' cache [...done]
Retrieving repository 'csm-sle-15sp5' metadata [...done]
Building repository 'csm-sle-15sp5' cache [...done]
All repositories have been refreshed.
Loading repository data...
Reading installed packages...
'craycli' is already installed.
No update candidate for 'craycli-0.82.10-1.x86_64'. The highest available version is already installed.
'hpe-csm-goss-package' is already installed.
No update candidate for 'hpe-csm-goss-package-0.3.21-hpe4.x86_64'. The highest available version is already installed.
'platform-utils' is already installed.
No update candidate for 'platform-utils-1.6.7-1.noarch'. The highest available version is already installed.
Resolving package dependencies...
The following package is going to be upgraded:
  goss-servers
The following 6 NEW packages are going to be installed:
  cani canu cray-cmstools-crayctldeploy csm-testing iuf-cli libcsm
The following 7 packages have no support information from their vendor:
  cani canu cray-cmstools-crayctldeploy csm-testing goss-servers iuf-cli libcsm
1 package to upgrade, 6 new.
Overall download size: 129.2 MiB. Already cached: 0 B. After the operation, additional 271.1 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving: csm-testing-1.16.59-1.noarch (csm-noos) (1/7), 155.0 KiB
Retrieving: csm-testing-1.16.59-1.noarch.rpm [.done]
Retrieving: goss-servers-1.16.59-1.noarch (csm-noos) (2/7),  12.4 KiB
Retrieving: goss-servers-1.16.59-1.noarch.rpm [.done]
Retrieving: cani-0.3.0-1.x86_64 (csm-noos) (3/7),   6.5 MiB
Retrieving: cani-0.3.0-1.x86_64.rpm [.done]
Retrieving: canu-1.7.6-1.x86_64 (csm-noos) (4/7),  84.7 MiB
Retrieving: canu-1.7.6-1.x86_64.rpm [...done (65.4 MiB/s)]
Retrieving: cray-cmstools-crayctldeploy-1.14.1-1.x86_64 (csm-noos) (5/7),  15.1 MiB
Retrieving: cray-cmstools-crayctldeploy-1.14.1-1.x86_64.rpm [.done]
Retrieving: iuf-cli-1.5.6-1.x86_64 (csm-noos) (6/7),  11.4 MiB
Retrieving: iuf-cli-1.5.6-1.x86_64.rpm [.done]
Retrieving: libcsm-0.0.5-1.noarch (csm-sle-15sp5) (7/7),  11.2 MiB
Retrieving: libcsm-0.0.5-1.noarch.rpm [.done]
Checking for file conflicts: [......done]
(1/7) Installing: csm-testing-1.16.59-1.noarch [...done]
(2/7) Installing: goss-servers-1.16.59-1.noarch [..
Removed /etc/systemd/system/multi-user.target.wants/goss-servers.service.
..done]
(3/7) Installing: cani-0.3.0-1.x86_64 [......done]
(4/7) Installing: canu-1.7.6-1.x86_64 [.................................done]
(5/7) Installing: cray-cmstools-crayctldeploy-1.14.1-1.x86_64 [............done]
(6/7) Installing: iuf-cli-1.5.6-1.x86_64 [......done]
(7/7) Installing: libcsm-0.0.5-1.noarch [......................done]
```


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
To test this, I set up an environment with a new PIT image with the CSM 1.5.0-beta.71 tarball.

I installed my new cray-site-init package. Then I regenerated all of my configs (as well as the site-init directory), uploaded the tarball to nexus, and ran `/root/bin/pit-init.sh` (following the docs).

Before booting, I removed all of the `runcmd` entries. This was to facilitate debugging, so I could observe the state of the node before `net-init.sh` was invoked.