### PR TITLE
CASMPET-6835: Fix cilium-kube-proxy-replacement name

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -833,16 +833,16 @@ func validateFlags() []string {
 		}
 	}
 
-	if v.IsSet("kube-proxy-replacement") {
+	if v.IsSet("cilium-kube-proxy-replacement") {
 		validFlag := false
 		for _, value := range [3]string{"strict", "partial", "disabled"} {
-			if v.GetString("kube-proxy-replacement") == value {
+			if v.GetString("cilium-kube-proxy-replacement") == value {
 				validFlag = true
 				break
 			}
 		}
 		if !validFlag {
-			errors = append(errors, fmt.Sprintf("kube-proxy-replacement must be set to strict, partial, or disabled"))
+			errors = append(errors, fmt.Sprintf("cilium-kube-proxy-replacement must be set to strict, partial, or disabled"))
 		}
 	}
 

--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -111,7 +111,7 @@ type BaseCampGlobals struct {
 	KubernetesWeaveMTU         string `json:"kubernetes-weave-mtu"`     // 1376
 	KubernetesCiliumOpReplicas string `json:"cilium-operator-replicas"` // 1
 	KubernetesPrimaryCNI       string `json:"k8s-primary-cni"`          // weave
-	KubernetesKubeProxyReplace string `json:"kube-proxy-replacement"`   // strict
+	KubernetesKubeProxyReplace string `json:"cilium-kube-proxy-replacement"`   // strict
 
 	NumStorageNodes int `json:"num_storage_nodes"`
 }
@@ -166,7 +166,7 @@ var basecampGlobalString = `{
 	"kubernetes-weave-mtu": "1376",
 	"cilium-operator-replicas": "1",
 	"k8s-primary-cni": "weave",
-	"kube-proxy-replacement": "strict",
+	"cilium-kube-proxy-replacement": "strict",
 	"rgw-virtual-ip": "~FIXME~ e.g. 10.252.2.100",
 	"wipe-ceph-osds": "yes",
 	"system-name": "~FIXME~",


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes:  https://jira-pro.it.hpe.com:8443/browse/CASMPET-6835



#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

Changes kube-proxy-replacement to cilium-kube-proxy-replacement to match up with kubernetes-cloudinit.sh.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
