### PR TITLE
CASMPET-6917 - csi handoff bss-metadata should ignore Cilium lxc interfaces

### DIFF
--- a/cmd/handoff-bss-metadata.go
+++ b/cmd/handoff-bss-metadata.go
@@ -308,7 +308,8 @@ func getMACsFromString(macAddrStrings string) (ncnMacs []string) {
 			interfaceName == "dummy" ||
 			interfaceName == "lo" ||
 			strings.Contains(interfaceName, "usb") ||
-			strings.Contains(interfaceName, "veth") {
+			strings.Contains(interfaceName, "veth") ||
+			strings.Contains(interfaceName, "lxc") {
 			continue
 		}
 

--- a/cmd/handoff-bss-metadata.go
+++ b/cmd/handoff-bss-metadata.go
@@ -309,6 +309,9 @@ func getMACsFromString(macAddrStrings string) (ncnMacs []string) {
 			interfaceName == "lo" ||
 			strings.Contains(interfaceName, "usb") ||
 			strings.Contains(interfaceName, "veth") ||
+			strings.Contains(interfaceName, "weave") ||
+			strings.Contains(interfaceName, "cilium") ||
+			strings.Contains(interfaceName, "kube") ||
 			strings.Contains(interfaceName, "lxc") {
 			continue
 		}

--- a/pkg/pit/basecamp.go
+++ b/pkg/pit/basecamp.go
@@ -111,7 +111,7 @@ type BaseCampGlobals struct {
 	KubernetesWeaveMTU         string `json:"kubernetes-weave-mtu"`     // 1376
 	KubernetesCiliumOpReplicas string `json:"cilium-operator-replicas"` // 1
 	KubernetesPrimaryCNI       string `json:"k8s-primary-cni"`          // weave
-	KubernetesKubeProxyReplace string `json:"cilium-kube-proxy-replacement"`   // strict
+	KubernetesKubeProxyReplace string `json:"cilium-kube-proxy-replacement"`   // disabled
 
 	NumStorageNodes int `json:"num_storage_nodes"`
 }
@@ -166,7 +166,7 @@ var basecampGlobalString = `{
 	"kubernetes-weave-mtu": "1376",
 	"cilium-operator-replicas": "1",
 	"k8s-primary-cni": "weave",
-	"cilium-kube-proxy-replacement": "strict",
+	"cilium-kube-proxy-replacement": "disabled",
 	"rgw-virtual-ip": "~FIXME~ e.g. 10.252.2.100",
 	"wipe-ceph-osds": "yes",
 	"system-name": "~FIXME~",


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMPET-6917](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6917)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

`csi` already ignores Weave `veth` interfaces when populating HSM ethernetInterfaces with NCN MAC addresses.

A similar exclusion is required for Cilium `lxc` interfaces to avoid cluttering up ethernetInterfaces with unnecessary records.

This PR also disables the kube-proxy replacement by default as there are problems with it and TFTP ([CASMPET-6763](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6763))
<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

This was tested on surtur and had the desired effect however the system was reinstalled before I could preserve the output and I cannot test this change again until the next CSM 1.6 fresh install with Cilium as the default CNI.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
