### PR TITLE
Always set `GOARCH`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ ifeq ($(GOARCH),)
 		export GOARCH=arm64
 	else ifeq "$(ARCH)" "x86_64"
 		export GOARCH=amd64
+	else
+		export GOARCH=$(ARCH)
 	endif
 endif
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Minor detail, but if `GOARCH` is only set if the resolved `ARCH` is explicitly `aarch64` or `x86_64`. On M1/M2/M3 MacBooks the `ARCH` resolves to `arm64`.

This is not very important, because `GOARCH` will auto-resolve itself when Go compiles, but it looks goofy in the build output with `GOARCH=<nothing>`.

Before:
```bash
rusty@HPE-XHD22YD7DW:~/gitstuffs/cray-shasta/csi> make bin/csi
GOOS=darwin GOARCH= go build -o bin/csi -ldflags "\
        -X github.com/Cray-HPE/cray-site-init/pkg/version.version=v1.32.7 \
        -X github.com/Cray-HPE/cray-site-init/pkg/version.buildDate=2024-05-08T03:08:31Z \
        -X github.com/Cray-HPE/cray-site-init/pkg/version.sha1ver=ebab5feccbafb9cad370e3be82f78ac19e3950be-main-dirty"
# github.com/Cray-HPE/cray-site-init
ld: warning: -bind_at_load is deprecated on macOS
```

After:
```bash
rusty@HPE-XHD22YD7DW:~/gitstuffs/cray-shasta/csi> make bin/csi
GOOS=darwin GOARCH=arm64 go build -o bin/csi -ldflags "\
        -X github.com/Cray-HPE/cray-site-init/pkg/version.version=v1.32.7 \
        -X github.com/Cray-HPE/cray-site-init/pkg/version.buildDate=2024-05-08T03:09:34Z \
        -X github.com/Cray-HPE/cray-site-init/pkg/version.sha1ver=ebab5feccbafb9cad370e3be82f78ac19e3950be-main-dirty"
^Cmake: *** [bin/csi] Interrupt: 2

```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
