### PR TITLE
CASMTRIAGE-7012

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -802,7 +802,7 @@ func validateFlags() []string {
 		"site-gw",
 	}
 	for _, flagName := range ipv4Flags {
-		if v.IsSet(flagName) {
+		if v.IsSet(flagName) && v.GetString(flagName) != "" {
 			if net.ParseIP(v.GetString(flagName)) == nil {
 				errors = append(errors, fmt.Sprintf("%v should be an ip address and is not set correctly through flag or config file (.%s)", flagName, v.ConfigFileUsed()))
 			}


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7012

Validate only non-empty ipv4 addresses.

Ignore **chn-gateway: ""**
Validate **chn-gateway: 10.102.103.129**

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
  
### Risks and Mitigations
 
none known