### PR TITLE
MTL-2404 `--kubeconfig` flag is not recognized

### DIFF
--- a/pkg/cli/automation/ncn/ncn.go
+++ b/pkg/cli/automation/ncn/ncn.go
@@ -47,7 +47,7 @@ func NewCommand() *cobra.Command {
 		Long:              "A series of subcommands that automates NCN administrative tasks.",
 		DisableAutoGenTag: true,
 	}
-	c.Flags().StringVar(
+	c.PersistentFlags().StringVar(
 		&kubeconfig,
 		"kubeconfig",
 		"",

--- a/pkg/cli/automation/ncn/ncn.go
+++ b/pkg/cli/automation/ncn/ncn.go
@@ -47,9 +47,10 @@ func NewCommand() *cobra.Command {
 		Long:              "A series of subcommands that automates NCN administrative tasks.",
 		DisableAutoGenTag: true,
 	}
-	c.PersistentFlags().StringVar(
+	c.PersistentFlags().StringVarP(
 		&kubeconfig,
 		"kubeconfig",
+		"k",
 		"",
 		"Absolute path to the kubeconfig file",
 	)


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2404
- Relates to: #391 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `automate ncn` command's `--kubeconfig` flag is not recognized by any subcommands.
    
Change the flag to a persistent flag in the `ncn` package.

**Before** `--kubeconfig` does *not* appear as a valid flag for the `kubernetes` subcommand.
```bash
[612]rusty@HPE-XHD22YD7DW:~/gitstuffs/cray-shasta/csi> ./csi version
CRAY-Site-Init build signature...
Build Commit   : fe6eeacfbf447becf3af6cff386006628989c82b-main
Build Time     : 2024-06-30T07:00:31Z
Go Version     : go1.22.4
Version        : 1.33.1
Platform       : darwin/arm64
[613]rusty@HPE-XHD22YD7DW:~/gitstuffs/cray-shasta/csi> ./csi automate ncn kubernetes --help
A series of subcommands that automates administrative tasks to Kubernetes.

Usage:
  csi automate ncn kubernetes [flags]

Flags:
      --action string   The etcd action to perform (cordon-ncn/uncordon-ncn/drain-ncn/delete-ncn/is-member)
  -h, --help            help for kubernetes
      --ncn string      The NCN to perform the action on

Global Flags:
  -c, --config string   CSI config file
```

**After** `--kubeconfig` appears as a valid flag for the `kubernetes` subcommand.

```bash
[636]rusty@HPE-XHD22YD7DW:~/gitstuffs/cray-shasta/csi> ./csi version
CRAY-Site-Init build signature...
Build Commit   : 0dd06db472e25860f24d467790ced2f1fb360287-MTL-2404
Build Time     : 2024-06-30T07:11:17Z
Go Version     : go1.22.4
Version        : 1.33.1~2~g0dd06db4
Platform       : darwin/arm64
[637]rusty@HPE-XHD22YD7DW:~/gitstuffs/cray-shasta/csi> ./csi automate ncn kubernetes --help
A series of subcommands that automates administrative tasks to Kubernetes.

Usage:
  csi automate ncn kubernetes [flags]

Flags:
      --action string   The etcd action to perform (cordon-ncn/uncordon-ncn/drain-ncn/delete-ncn/is-member)
  -h, --help            help for kubernetes
      --ncn string      The NCN to perform the action on

Global Flags:
  -c, --config string       CSI config file
  -k, --kubeconfig string   Absolute path to the kubeconfig file
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
