### PR TITLE
MTL-2424

### DIFF
--- a/pkg/cli/config/initialize/dnsmasq.go
+++ b/pkg/cli/config/initialize/dnsmasq.go
@@ -122,7 +122,7 @@ type DNSMasqBootstrapNetwork struct {
 	Interface string
 }
 
-// WriteDNSMasqConfig writes the dnsmasq configuration files necssary for installation
+// WriteDNSMasqConfig writes the dnsmasq configuration files necessary for installation
 func WriteDNSMasqConfig(
 	path string, v *viper.Viper, bootstrap []LogicalNCN, networks map[string]*networking.IPV4Network,
 ) {

--- a/pkg/cli/config/initialize/dnsmasq.go
+++ b/pkg/cli/config/initialize/dnsmasq.go
@@ -69,6 +69,9 @@ interface-name=pit.{{.NetName | lower}},{{.InterfaceName}}
 dhcp-option=interface:{{.InterfaceName}},option:domain-search,{{.NetName | lower}}
 interface={{.InterfaceName}}
 cname=packages.{{.NetName | lower}},pit.{{.NetName | lower}}
+{{ if eq .NetName "MTL" -}}
+cname=packages.local,pit.{{.NetName | lower}}
+{{ end -}}
 cname=registry.{{.NetName | lower}},pit.{{.NetName | lower}}
 dhcp-option=interface:{{.InterfaceName}},option:dns-server,{{.PITServer}}
 dhcp-option=interface:{{.InterfaceName}},option:ntp-server,{{.PITServer}}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2424
- Relates to: #406 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

New `MTL.conf` containing the `packages.local` CNAME.
```ini
#
## This file was generated by cray-site-init.
#
# MTL:
server=/mtl/
address=/mtl/
domain=nmn,10.1.1.0,10.1.1.213,local
interface-name=pit.mtl,bond0
dhcp-option=interface:bond0,option:domain-search,mtl
interface=bond0
cname=packages.mtl,pit.mtl
cname=packages.local,pit.mtl
cname=registry.mtl,pit.mtl
dhcp-option=interface:bond0,option:dns-server,10.1.1.10
dhcp-option=interface:bond0,option:ntp-server,10.1.1.10
dhcp-option=interface:bond0,option:router,10.1.0.1
dhcp-range=interface:bond0,10.1.1.13,10.1.1.213,10m

```
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
