### PR TITLE
make `csi pit format --write-script` optional to fix CASMTRIAGE-7156

### DIFF
--- a/pkg/cli/pit/format.go
+++ b/pkg/cli/pit/format.go
@@ -45,12 +45,13 @@ func formatCommand(formatFunc WriteLiveCDFunc) *cobra.Command {
 		Short: "Formats a disk as a LiveCD",
 		Long:  `Formats a disk as a LiveCD using an ISO.`, // ValidArgs: []string{"disk", "iso", "size"},
 		Args:  cobra.ExactArgs(3),
-		Run: func(c *cobra.Command, args []string) {
+		RunE: func(c *cobra.Command, args []string) error {
 			device := args[0]
 			iso := args[1]
 			size := args[2]
 			fmt.Printf("Arguments received: device=%s, iso=%s, size=%s\n", device, iso, size) // Debugging statement
-			formatFunc(device, iso, size)
+			err := formatFunc(device, iso, size)
+			return err
 		},
 	}
 	viper.SetEnvPrefix("pit") // will be uppercased automatically

--- a/pkg/cli/pit/format_test.go
+++ b/pkg/cli/pit/format_test.go
@@ -1,0 +1,36 @@
+package pit
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func Test_FormatCommand(t *testing.T) {
+	b := bytes.NewBufferString("")
+	mockWriteFunc := WriteLiveCDFunc( // create a mock function that will write to the buffer since we do not want to actually format anything
+		func(device string, iso string, size string) error {
+			fmt.Fprint(b, "write-script flag not set")
+			return nil
+		})
+	cmd := formatCommand(mockWriteFunc)                 // create a new 'pit format' command using the mock function
+	cmd.SetOut(b)                                       // replace the stdout with something that we can read programmatically
+	cmd.SetErr(b)                                       // replace the stderr with something that we can read programmatically
+	cmd.SetArgs([]string{"/dev/mock", "mock.iso", "1"}) // set the required args for the command
+	// the write-script flag should be optional, so do not set it
+
+	err := cmd.Execute() // execute the command
+	if err != nil {
+		t.Fatalf("cmd.Execute() failed: %v", err)
+	}
+	out, err := io.ReadAll(b) // read the output
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// if
+	if string(out) != "write-script flag not set" {
+		t.Fatalf("expected \"%s\" got \"%s\"", "write-script flag not set", string(out))
+	}
+}

--- a/pkg/cli/pit/pit.go
+++ b/pkg/cli/pit/pit.go
@@ -45,7 +45,7 @@ the liveCD tool. Fetches artifacts for deployment.`,
 		},
 	}
 	c.AddCommand(
-		formatCommand(),
+		formatCommand(writeLiveCD),
 		getCommand(),
 		validateCommand(),
 	)


### PR DESCRIPTION
this commit could have been a one line change to remove the
MarkFlagRequired() directive, but in an effort to improve the quality
and confidence of our tooling, I opted to create a new test for this.

this involved creating a new type, WriteLiveCDFunc, which is accepted as
a parameter.

this is required to replace the real implementation with a mock in the
go tests.  this is especially important in this function since it could
destructively format a disk, so if you accidently gave it some bad
parameters, there is a possibility it may format something unintended.
this also allows finer control over what portions of the function to
test.

in this case, I mererly test that the function does not require the
--write-script flag.

further tests could certainly be added, but as CSM is EOL, I am adding
best effort tests here without going overboard.

this flag was actually marked required prior to the refactor by @rustydb
in https://github.com/Cray-HPE/cray-site-init/pull/391/files#diff-560a2ff11144e84b5ea4611785932f2f29ed01f545fbf1b61c83de7b4a56c07eL82

it is likely that the poor layout of this project at that time prevented
it from being enforced.  either way, it does not need to be a required
flag since we set a default that is used in almost all cases and having
it required deviates from the documenation and causes confusion.

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>