### PR TITLE
MTL-2450 - Remove unused hsn-dynamic-pool and hsn-static-pool parameters

### DIFF
--- a/pkg/cli/config/initialize/initialize.go
+++ b/pkg/cli/config/initialize/initialize.go
@@ -864,21 +864,6 @@ func NewCommand() *cobra.Command {
 		slsInit.DefaultHSNString,
 		"Overall IPv4 CIDR for all HSN subnets",
 	)
-	c.Flags().String(
-		"hsn-static-pool",
-		"",
-		"Overall IPv4 CIDR for static High Speed load balancer addresses",
-	)
-	c.Flags().String(
-		"hsn-dynamic-pool",
-		"",
-		"Overall IPv4 CIDR for dynamic High Speed load balancer addresses",
-	)
-	c.MarkFlagsRequiredTogether(
-		"hsn-cidr",
-		"hsn-static-pool",
-		"hsn-dynamic-pool",
-	)
 
 	// Misc network.
 	c.Flags().Bool(


### PR DESCRIPTION
### Summary and Scope

The following two CSI flags were marked deprecated

```
      --hsn-dynamic-pool string               Overall IPv4 CIDR for dynamic High Speed load balancer addresses
      --hsn-static-pool string                Overall IPv4 CIDR for static High Speed load balancer addresses
```

The parameters re-added by a recent refactor. [MTL-2396](https://jira-pro.it.hpe.com:8443/browse/MTL-2396) https://github.com/Cray-HPE/cray-site-init/pull/391

This PR removes them again.

- Fixes: [MTL-2450](https://jira-pro.it.hpe.com:8443/browse/MTL-2450)

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

The `hsn-dynamic-pool` and `hsn-static-pool` flags are no longer visible

```bash
# csi config init --help | grep hsn
      --hsn-cidr string                       Overall IPv4 CIDR for all HSN subnets (default "10.253.0.0/16")
```
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
