### PR TITLE
MTL-2498

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -64,7 +64,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ARCH'
-                        values 'x86_64', 'aarch64'
+                        values 'x86_64'
                     }
                 }
 


### PR DESCRIPTION
### Summary and Scope

aarch64 builds are failing. Temporarily removing aarch64 until after the CSM 1.6 release.

https://jira-pro.it.hpe.com:8443/browse/MTL-2498

#### Issue Type

- Bugfix Pull Request