### PR TITLE
MTL-2499

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -64,7 +64,7 @@ pipeline {
                 axes {
                     axis {
                         name 'ARCH'
-                        values 'x86_64'
+                        values 'x86_64', 'aarch64'
                     }
                 }
 

--- a/go.mod
+++ b/go.mod
@@ -137,5 +137,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-go 1.21
-toolchain go1.22.5
+go 1.22


### PR DESCRIPTION
### Summary and Scope

Although we had 1.21 set in the "go" directive, the last tagged release was built on 1.22 so the Go version change in this PR is effectively no change.

- Fixes: incorrect Go version
https://jira-pro.it.hpe.com:8443/browse/MTL-2499

- MTL-2498 resolved itself so aarch64 builds were added back in
https://jira-pro.it.hpe.com:8443/browse/MTL-2498

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)