### PR TITLE
Add VLAN management with overlap and re-use checks

### DIFF
--- a/pkg/cli/config/initialize/sls/networkBuilder.go
+++ b/pkg/cli/config/initialize/sls/networkBuilder.go
@@ -78,7 +78,7 @@ Handy Netmask Cheet Sheet
 
 const (
 	// DefaultMTLVlan is the default MTL Bootstrap Vlan - zero (0) represents untagged.
-	DefaultMTLVlan = 0
+	DefaultMTLVlan = 1
 	// DefaultHMNString is the Default HMN String (bond0.hmn0)
 	DefaultHMNString = "10.254.0.0/17"
 	// DefaultHMNVlan is the default HMN Bootstrap Vlan

--- a/pkg/networking/ipam.go
+++ b/pkg/networking/ipam.go
@@ -599,6 +599,7 @@ var netmasks = map[int]string{
 // Basic VLAN management
 var vlans = [4096]bool{4095: true}
 
+// Test to see if a given VLAN is already allocated and managed.
 func IsVlanAllocated(vlan int16) (bool, error) {
 	if vlan > 4095 || vlan < 0 {
 		return true, errors.New("VLAN out of range")
@@ -606,6 +607,7 @@ func IsVlanAllocated(vlan int16) (bool, error) {
 	return vlans[vlan], nil
 }
 
+// Allocate and manage a single VLAN.
 func AllocateVlan(vlan int16) error {
 	allocated, err := IsVlanAllocated(vlan)
 	if allocated {
@@ -618,11 +620,13 @@ func AllocateVlan(vlan int16) error {
 	return nil
 }
 
+// Free a single VLAN from management.
 func FreeVlan(vlan int16) error {
 	vlans[vlan] = false
 	return nil
 }
 
+// Allocate and manage a range of VLANs.
 func AllocateVlanRange(startvlan, endvlan int16) error {
 	if startvlan > endvlan {
 		return errors.New("VLAN range is bad - start is larger than end")
@@ -650,6 +654,7 @@ func AllocateVlanRange(startvlan, endvlan int16) error {
 	return nil
 }
 
+// Free a range of VLANs from management.
 func FreeVlanRange(startvlan, endvlan int16) error {
 	if startvlan > endvlan {
 		return errors.New("VLAN range is bad - start is larger than end")

--- a/pkg/networking/ipam.go
+++ b/pkg/networking/ipam.go
@@ -599,7 +599,7 @@ var netmasks = map[int]string{
 // Basic VLAN management
 var vlans = [4096]bool{4095: true}
 
-// Test to see if a given VLAN is already allocated and managed.
+// IsVlanAllocated takes an int16 and tests if a given VLAN is already allocated and managed.
 func IsVlanAllocated(vlan int16) (bool, error) {
 	if vlan > 4095 || vlan < 0 {
 		return true, errors.New("VLAN out of range")
@@ -607,7 +607,7 @@ func IsVlanAllocated(vlan int16) (bool, error) {
 	return vlans[vlan], nil
 }
 
-// Allocate and manage a single VLAN.
+// AllocateVlan takes an int16 and manages a single VLAN.
 func AllocateVlan(vlan int16) error {
 	allocated, err := IsVlanAllocated(vlan)
 	if allocated {
@@ -620,13 +620,13 @@ func AllocateVlan(vlan int16) error {
 	return nil
 }
 
-// Free a single VLAN from management.
+// FreeVlan takes an int16 and stops managing a single VLAN.
 func FreeVlan(vlan int16) error {
 	vlans[vlan] = false
 	return nil
 }
 
-// Allocate and manage a range of VLANs.
+// AllocateVlanRange takes two int16 and manages a range of VLANs.
 func AllocateVlanRange(startvlan, endvlan int16) error {
 	if startvlan > endvlan {
 		return errors.New("VLAN range is bad - start is larger than end")
@@ -654,7 +654,7 @@ func AllocateVlanRange(startvlan, endvlan int16) error {
 	return nil
 }
 
-// Free a range of VLANs from management.
+// FreeVlanRange takes two int16 and stops managing a range of VLANs.
 func FreeVlanRange(startvlan, endvlan int16) error {
 	if startvlan > endvlan {
 		return errors.New("VLAN range is bad - start is larger than end")

--- a/pkg/networking/ipam_test.go
+++ b/pkg/networking/ipam_test.go
@@ -1,0 +1,214 @@
+/*
+ MIT License
+
+ (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package networking
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type NetworksTestSuite struct {
+	suite.Suite
+}
+
+func (suite *NetworksTestSuite) TestIsVlanAllocatedBadVlans() {
+	tests := []struct {
+		vlan          int16
+		expectedBool  bool
+		expectedError error
+	}{
+		{
+			// VLAN out of range too small
+			vlan:          -1,
+			expectedBool:  true,
+			expectedError: errors.New("VLAN out of range"),
+		},
+		{
+			// VLAN out of range too big
+			vlan:          4096,
+			expectedBool:  true,
+			expectedError: errors.New("VLAN out of range"),
+		},
+	}
+
+	for _, test := range tests {
+		val, err := IsVlanAllocated(test.vlan)
+		suite.Equal(
+			val,
+			test.expectedBool,
+		)
+		suite.Equal(
+			test.expectedError,
+			err,
+		)
+	}
+}
+
+func (suite *NetworksTestSuite) TestAllocateVlanBadVlans() {
+	tests := []struct {
+		vlan          int16
+		expectedError error
+	}{
+		{
+			// VLAN out of range too small
+			vlan:          -1,
+			expectedError: errors.New("VLAN out of range"),
+		},
+		{
+			// VLAN out of range too big
+			vlan:          4096,
+			expectedError: errors.New("VLAN out of range"),
+		},
+		{
+			// VLAN 7 not allocated and this should work
+			vlan:          7,
+			expectedError: nil,
+		},
+	}
+
+	for _, test := range tests {
+		err := AllocateVlan(test.vlan)
+		suite.Equal(
+			test.expectedError,
+			err,
+		)
+	}
+}
+
+func (suite *NetworksTestSuite) TestVlanAllocate() {
+	// Allocate VLAN 2 the first time should be success
+	var vlan int16 = 2
+	suite.Equal(
+		nil,
+		AllocateVlan(vlan),
+	)
+	//Allocate VLAN 2 the 2nd time should fail as it's already used
+	suite.Equal(
+		errors.New("VLAN already used"),
+		AllocateVlan(vlan),
+	)
+}
+
+func (suite *NetworksTestSuite) TestVlanAllocateRange() {
+	// Bad start and end range
+	suite.Equal(
+		errors.New("VLAN out of range"),
+		AllocateVlanRange(4092, 4099),
+	)
+
+	var startVlan int16 = 200
+	var endVlan int16 = 299
+
+	// Bad start and end range
+	suite.Equal(
+		errors.New("VLAN range is bad - start is larger than end"),
+		AllocateVlanRange(endVlan, startVlan),
+	)
+
+	// VLANs already in use in the range cannot be allocated, including ends
+	AllocateVlan(200)
+	AllocateVlan(207)
+	AllocateVlan(213)
+	AllocateVlan(299)
+	suite.Equal(
+		errors.New("VLANs already used: [200 207 213 299]"),
+		AllocateVlanRange(startVlan, endVlan),
+	)
+
+	// Successfully allocate a range of VLANs
+	FreeVlan(200)
+	FreeVlan(207)
+	FreeVlan(213)
+	FreeVlan(299)
+	suite.Equal(
+		nil,
+		AllocateVlanRange(startVlan, endVlan),
+	)
+}
+
+func (suite *NetworksTestSuite) TestVlanFree() {
+	// Allocate VLAN 4
+	var vlan int16 = 4
+	suite.Equal(
+		nil,
+		AllocateVlan(vlan),
+	)
+
+	// Deallocate VLAN 4 the 1st time should succeed
+	suite.Equal(
+		nil,
+		FreeVlan(vlan),
+	)
+
+	// Deallocate VLAN 4 the 2nd time should succeed
+	suite.Equal(
+		nil,
+		FreeVlan(vlan),
+	)
+}
+
+func (suite *NetworksTestSuite) TestVlanFreeRange() {
+	var startVlan int16 = 400
+	var endVlan int16 = 499
+	suite.Equal(
+		errors.New("VLAN range is bad - start is larger than end"),
+		FreeVlanRange(endVlan, startVlan),
+	)
+
+	AllocateVlan(startVlan)
+	AllocateVlan(endVlan)
+	// Deallocate the range the first time - should succeed
+	suite.Equal(
+		nil,
+		FreeVlanRange(startVlan, endVlan),
+	)
+
+	startAllocation, _ := IsVlanAllocated(startVlan)
+	suite.Equal(
+		false,
+		startAllocation,
+	)
+
+	endAllocation, _ := IsVlanAllocated(endVlan)
+	suite.Equal(
+		false,
+		endAllocation,
+	)
+
+	// Deallocate the range the second time - should still succeed
+	suite.Equal(
+		nil,
+		FreeVlanRange(startVlan, endVlan),
+	)
+
+}
+func TestNetworksTestSuite(t *testing.T) {
+	suite.Run(
+		t,
+		new(NetworksTestSuite),
+	)
+}


### PR DESCRIPTION
### Summary and Scope

Previously CSI allowed VLANs to be used for multiple networks.  For example, VLAN 4 is the usual default for the HMN, but might also erroneously be used on the command line or `system_config.yaml` to specify other networks - say the NMN or CMN. This caused errors during installation and runtime for the switch configurations.

This change introduces VLAN validation and management in the IPAM module. The functions both allocate and free VLANs from management as well as check to see if a VLAN has previously been used or is in an incorrect range.  These functions have been used in `csi config init` after network structure initialization and assignment of VLAN values from the CLI and `system_config.yaml` values. While this is relatively late in the process, the random nature of the range loop over the networks map prevented consistent handling earlier.

To reuse a VLAN is a fatal error in `csi config init`. Allocation of VLANs and all errors are logged. Two samples of errors follow:

```shell
2024/10/15 19:27:50 Allocating VLANs HMN_RVR 1513 1769
2024/10/15 19:27:50 Allocating VLAN  CMN 7
2024/10/15 19:27:50 Allocating VLANs HMN_MTN 3000 3999
2024/10/15 19:27:50 Allocating VLANs HSN 613 868
2024/10/15 19:27:50 Allocating VLAN  MTL 1
2024/10/15 19:27:50 Unable to allocate single VLAN for NMN 3998 VLAN already used
```

```shell
2024/10/16 12:26:37 Allocating VLAN  HMN 4
2024/10/16 12:26:37 Allocating VLANs HSN 613 868
2024/10/16 12:26:37 Unable to allocate single VLAN for NMN 4099 VLAN out of range
```

Also of note is that the MTL VLAN default has been changed from 0 to 1. While in reality a VLAN of 0 is either out of range for some vendors or specifies priority tagging in Cisco devices, in CSM a VLAN of 0 was used as a placeholder that was overridden elsewhere. Both the MTL and BICAN networks used VLAN 0 and with the addition of VLAN management here, the previous use caused an error.  In most of CSM, including CANU, the MTL VLAN defaults to 1 anyway so this change in CSI should, for all practical purposes be a no-op.

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [MTL-2437](https://jira-pro.it.hpe.com:8443/browse/MTL-2437)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
The assignment loop in `csi config init` is a range over a map of networks. This is inherently a random ordering in Go. To preserve idempotency VLAN management and checks needed to be after network structure initialization and assignment. With this method, VLAN overlaps/re-use are consistently caught, though the order of the error(s) may be different.
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

Risk introduced by this change should be reduced since better error checking is employed on VLANs.

-->
