### PR TITLE
CASMTRIAGE-7424 Remove `bond0.mtl0`

### DIFF
--- a/pkg/cli/config/initialize/sls/networkBuilder.go
+++ b/pkg/cli/config/initialize/sls/networkBuilder.go
@@ -77,7 +77,7 @@ Handy Netmask Cheet Sheet
 */
 
 const (
-	// DefaultMTLVlan is the default MTL Bootstrap Vlan - zero (0) represents untagged.
+	// DefaultMTLVlan is the default MTL Bootstrap Vlan - one (1) represents untagged.
 	DefaultMTLVlan = 1
 	// DefaultHMNString is the Default HMN String (bond0.hmn0)
 	DefaultHMNString = "10.254.0.0/17"

--- a/pkg/networking/ipam_test.go
+++ b/pkg/networking/ipam_test.go
@@ -1,7 +1,7 @@
 /*
  MIT License
 
- (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/networking/network.go
+++ b/pkg/networking/network.go
@@ -682,7 +682,7 @@ func (iSubnet *IPV4Subnet) GenInterfaceName() error {
 			iSubnet.NetName,
 		)
 	}
-	if iSubnet.VlanID < 1 {
+	if iSubnet.VlanID <= 1 {
 		iSubnet.InterfaceName = fmt.Sprintf(
 			"%s",
 			iSubnet.ParentDevice,


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-7424
- Relates to: #432 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
#432 introduced VLAN checking that changed the default VLAN for the Metal network. This change bypassed the clause in `GenInterfaceName` for tying the metal network to `bond0`, instead the metal network was tied to `bond0.mtl0`.

This caused some strange behavior:
- bond0 was still created by other parts of csi and has a metal IP
- bond0.mtl0 is created and has the same IP as bond0
- dnsmasq gets configured to use bond0.mtl0, which has no routes
- PXE fails

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This change results in a dnsmasq config for MTL that references the correct interface:

```
#
## This file was generated by cray-site-init.
#
# MTL:
server=/mtl/
address=/mtl/
domain=nmn,10.1.1.0,10.1.1.213,local
interface-name=pit.mtl,bond0
dhcp-option=interface:bond0,option:domain-search,mtl
interface=bond0
cname=packages.mtl,pit.mtl
cname=packages.local,pit.mtl
cname=registry.mtl,pit.mtl
dhcp-option=interface:bond0,option:dns-server,10.1.1.10
dhcp-option=interface:bond0,option:ntp-server,10.1.1.10
dhcp-option=interface:bond0,option:router,10.1.0.1
dhcp-range=interface:bond0,10.1.1.13,10.1.1.213,10m
```
