### PR TITLE
MTL-2508 Avoid hard coded vlans for MTL

### DIFF
--- a/pkg/cli/config/initialize/basecamp.go
+++ b/pkg/cli/config/initialize/basecamp.go
@@ -586,7 +586,7 @@ func MakeBaseCampfromNCNs(
 		ncnIPAM := make(map[string]interface{})
 		for _, ncnNetwork := range ncn.Networks {
 
-			// Kea doesn't support multiple networks with vlan=0 so we need to special case CHN to not include in the ipam output
+			// The CHN is configured as a subnet of the HSN which is not done by basecamp, but by SHS and Ansible.
 			if strings.ToLower(ncnNetwork.NetworkName) == "chn" {
 				continue
 			}

--- a/pkg/cli/config/initialize/basecamp.go
+++ b/pkg/cli/config/initialize/basecamp.go
@@ -594,7 +594,14 @@ func MakeBaseCampfromNCNs(
 			ncnNICSubnet := make(map[string]interface{})
 			ncnNICSubnet["gateway"] = ncnNetwork.Gateway
 			ncnNICSubnet["ip"] = ncnNetwork.CIDR
-			ncnNICSubnet["vlanid"] = ncnNetwork.Vlan
+
+			// Fix cloud-init and remove this shenanigan
+			if strings.ToLower(ncnNetwork.NetworkName) == "mtl" {
+				ncnNICSubnet["vlanid"] = 0
+			} else {
+				ncnNICSubnet["vlanid"] = ncnNetwork.Vlan
+			}
+
 			ncnNICSubnet["parent_device"] = ncnNetwork.ParentInterfaceName
 			ncnIPAM[strings.ToLower(ncnNetwork.NetworkName)] = ncnNICSubnet
 		}

--- a/pkg/cli/config/initialize/initialize.go
+++ b/pkg/cli/config/initialize/initialize.go
@@ -173,7 +173,7 @@ func NewCommand() *cobra.Command {
 						3000,
 						3999,
 					}
-					tmpHmnMtn.Template.CIDR = slsInit.DefaultHMNMTNString
+					tmpHmnMtn.Template.CIDR = networking.DefaultHMNMTNString
 					tmpHmnMtn.SubdivideByCabinet = true
 					tmpHmnMtn.IncludeBootstrapDHCP = false
 					tmpHmnMtn.SuperNetHack = false
@@ -188,7 +188,7 @@ func NewCommand() *cobra.Command {
 						1513,
 						1769,
 					}
-					tmpHmnRvr.Template.CIDR = slsInit.DefaultHMNRVRString
+					tmpHmnRvr.Template.CIDR = networking.DefaultHMNRVRString
 					tmpHmnRvr.SubdivideByCabinet = true
 					tmpHmnRvr.IncludeBootstrapDHCP = false
 					tmpHmnRvr.SuperNetHack = false
@@ -207,7 +207,7 @@ func NewCommand() *cobra.Command {
 						2000,
 						2999,
 					}
-					tmpNmnMtn.Template.CIDR = slsInit.DefaultNMNMTNString
+					tmpNmnMtn.Template.CIDR = networking.DefaultNMNMTNString
 					tmpNmnMtn.SubdivideByCabinet = true
 					tmpNmnMtn.IncludeBootstrapDHCP = false
 					tmpNmnMtn.SuperNetHack = false
@@ -223,7 +223,7 @@ func NewCommand() *cobra.Command {
 						1770,
 						1999,
 					}
-					tmpNmnRvr.Template.CIDR = slsInit.DefaultNMNRVRString
+					tmpNmnRvr.Template.CIDR = networking.DefaultNMNRVRString
 					tmpNmnRvr.SubdivideByCabinet = true
 					tmpNmnRvr.IncludeBootstrapDHCP = false
 					tmpNmnRvr.SuperNetHack = false
@@ -742,7 +742,7 @@ func NewCommand() *cobra.Command {
 	// Node management network.
 	c.Flags().String(
 		"nmn-cidr",
-		slsInit.DefaultNMNString,
+		networking.DefaultNMNString,
 		"Overall IPv4 CIDR for all Node Management subnets",
 	)
 	c.Flags().String(
@@ -752,17 +752,17 @@ func NewCommand() *cobra.Command {
 	)
 	c.Flags().String(
 		"nmn-dynamic-pool",
-		slsInit.DefaultNMNLBString,
+		networking.DefaultNMNLBString,
 		"Overall IPv4 CIDR for dynamic Node Management load balancer addresses",
 	)
 	c.Flags().String(
 		"nmn-mtn-cidr",
-		slsInit.DefaultNMNMTNString,
+		networking.DefaultNMNMTNString,
 		"IPv4 CIDR for grouped Mountain Node Management subnets",
 	)
 	c.Flags().String(
 		"nmn-rvr-cidr",
-		slsInit.DefaultNMNRVRString,
+		networking.DefaultNMNRVRString,
 		"IPv4 CIDR for grouped River Node Management subnets",
 	)
 	_ = c.MarkFlagRequired("nmn-cidr")
@@ -770,7 +770,7 @@ func NewCommand() *cobra.Command {
 	// Hardware management network.
 	c.Flags().String(
 		"hmn-cidr",
-		slsInit.DefaultHMNString,
+		networking.DefaultHMNString,
 		"Overall IPv4 CIDR for all Hardware Management subnets",
 	)
 	c.Flags().String(
@@ -780,17 +780,17 @@ func NewCommand() *cobra.Command {
 	)
 	c.Flags().String(
 		"hmn-dynamic-pool",
-		slsInit.DefaultHMNLBString,
+		networking.DefaultHMNLBString,
 		"Overall IPv4 CIDR for dynamic Hardware Management load balancer addresses",
 	)
 	c.Flags().String(
 		"hmn-mtn-cidr",
-		slsInit.DefaultHMNMTNString,
+		networking.DefaultHMNMTNString,
 		"IPv4 CIDR for grouped Mountain Hardware Management subnets",
 	)
 	c.Flags().String(
 		"hmn-rvr-cidr",
-		slsInit.DefaultHMNRVRString,
+		networking.DefaultHMNRVRString,
 		"IPv4 CIDR for grouped River Hardware Management subnets",
 	)
 	_ = c.MarkFlagRequired("hmn-cidr")
@@ -888,14 +888,14 @@ func NewCommand() *cobra.Command {
 	// Metal network.
 	c.Flags().String(
 		"mtl-cidr",
-		slsInit.DefaultMTLString,
+		networking.DefaultMTLString,
 		"Overall IPv4 CIDR for all Provisioning subnets",
 	)
 
 	// High-speed network.
 	c.Flags().String(
 		"hsn-cidr",
-		slsInit.DefaultHSNString,
+		networking.DefaultHSNString,
 		"Overall IPv4 CIDR for all HSN subnets",
 	)
 
@@ -914,22 +914,22 @@ func NewCommand() *cobra.Command {
 	// Bootstrap VLANS
 	c.Flags().Int(
 		"can-bootstrap-vlan",
-		slsInit.DefaultCANVlan,
+		networking.DefaultCANVlan,
 		"Bootstrap VLAN for the CAN",
 	)
 	c.Flags().Int(
 		"cmn-bootstrap-vlan",
-		slsInit.DefaultCMNVlan,
+		networking.DefaultCMNVlan,
 		"Bootstrap VLAN for the CMN",
 	)
 	c.Flags().Int(
 		"hmn-bootstrap-vlan",
-		slsInit.DefaultHMNVlan,
+		networking.DefaultHMNVlan,
 		"Bootstrap VLAN for the HMN",
 	)
 	c.Flags().Int(
 		"nmn-bootstrap-vlan",
-		slsInit.DefaultNMNVlan,
+		networking.DefaultNMNVlan,
 		"Bootstrap VLAN for the NMN",
 	)
 

--- a/pkg/cli/config/initialize/networks.go
+++ b/pkg/cli/config/initialize/networks.go
@@ -35,6 +35,7 @@ import (
 
 	csiFiles "github.com/Cray-HPE/cray-site-init/internal/files"
 	"github.com/Cray-HPE/cray-site-init/pkg/cli"
+	"github.com/Cray-HPE/cray-site-init/pkg/cli/config/initialize/sls"
 
 	"github.com/Cray-HPE/cray-site-init/pkg/networking"
 )
@@ -137,7 +138,7 @@ func WriteCPTNetworkConfig(
 			network.NetworkName,
 			networking.ValidNetNames,
 		) {
-			if network.Vlan != 0 && network.NetworkName != "CHN" {
+			if network.Vlan != sls.DefaultMTLVlan && network.NetworkName != "CHN" {
 				csiFiles.WriteTemplate(
 					filepath.Join(
 						path,

--- a/pkg/cli/config/initialize/networks.go
+++ b/pkg/cli/config/initialize/networks.go
@@ -35,8 +35,6 @@ import (
 
 	csiFiles "github.com/Cray-HPE/cray-site-init/internal/files"
 	"github.com/Cray-HPE/cray-site-init/pkg/cli"
-	"github.com/Cray-HPE/cray-site-init/pkg/cli/config/initialize/sls"
-
 	"github.com/Cray-HPE/cray-site-init/pkg/networking"
 )
 
@@ -138,7 +136,7 @@ func WriteCPTNetworkConfig(
 			network.NetworkName,
 			networking.ValidNetNames,
 		) {
-			if network.Vlan != sls.DefaultMTLVlan && network.NetworkName != "CHN" {
+			if network.Vlan != networking.DefaultMTLVlan && network.NetworkName != "CHN" {
 				csiFiles.WriteTemplate(
 					filepath.Join(
 						path,

--- a/pkg/cli/config/initialize/sls/networkBuilder.go
+++ b/pkg/cli/config/initialize/sls/networkBuilder.go
@@ -57,206 +57,12 @@ type NetworkLayoutConfiguration struct {
 	ManagementSwitches              []*networking.ManagementSwitch
 }
 
-/*
-Handy Netmask Cheet Sheet
-/30	4	2	255.255.255.252	1/64
-/29	8	6	255.255.255.248	1/32
-/28	16	14	255.255.255.240	1/16
-/27	32	30	255.255.255.224	1/8
-/26	64	62	255.255.255.192	1/4
-/25	128	126	255.255.255.128	1/2
-/24	256	254	255.255.255.0	1
-/23	512	510	255.255.254.0	2
-/22	1024	1022	255.255.252.0	4
-/21	2048	2046	255.255.248.0	8
-/20	4096	4094	255.255.240.0	16
-/19	8192	8190	255.255.224.0	32
-/18	16384	16382	255.255.192.0	64
-/17	32768	32766	255.255.128.0	128
-/16	65536	65534	255.255.0.0	256
-*/
-
-const (
-	// DefaultMTLVlan is the default MTL Bootstrap Vlan - zero (0) represents untagged.
-	DefaultMTLVlan = 1
-	// DefaultHMNString is the Default HMN String (bond0.hmn0)
-	DefaultHMNString = "10.254.0.0/17"
-	// DefaultHMNVlan is the default HMN Bootstrap Vlan
-	DefaultHMNVlan = 4
-	// DefaultHMNMTNString is the default HMN Network for Mountain Cabinets with Grouped Configuration
-	DefaultHMNMTNString = "10.104.0.0/17"
-	// DefaultHMNRVRString is the default HMN Network for River Cabinets with Grouped Configuration
-	DefaultHMNRVRString = "10.107.0.0/17"
-	// DefaultNMNString is the Default NMN String (bond0.nmn0)
-	DefaultNMNString = "10.252.0.0/17"
-	// DefaultNMNVlan is the default NMN Bootstrap Vlan
-	DefaultNMNVlan = 2
-	// DefaultMacVlanVlan is the default MacVlan Bootstrap Vlan
-	DefaultMacVlanVlan = 2
-	// DefaultNMNMTNString is the default NMN Network for Mountain Cabinets with Grouped Configuration
-	DefaultNMNMTNString = "10.100.0.0/17"
-	// DefaultNMNRVRString is the default NMN Network for River Cabinets with Grouped Configuration
-	DefaultNMNRVRString = "10.106.0.0/17"
-	// DefaultNMNLBString is the default LoadBalancer CIDR for the NMN
-	DefaultNMNLBString = "10.92.100.0/24"
-	// DefaultHMNLBString is the default LoadBalancer CIDR for the HMN
-	DefaultHMNLBString = "10.94.100.0/24"
-	// DefaultMacVlanString is the default Macvlan cidr (shares vlan with NMN)
-	DefaultMacVlanString = "10.252.124.0/23"
-	// DefaultHSNString is the Default HSN String
-	DefaultHSNString = "10.253.0.0/16"
-	// DefaultCMNString is the Default CMN String (bond0.cmn0)
-	DefaultCMNString = "10.103.6.0/24"
-	// DefaultCMNVlan is the default CMN Bootstrap Vlan
-	DefaultCMNVlan = 7
-	// DefaultCANString is the Default CAN String (bond0.can0)
-	DefaultCANString = "10.102.11.0/24"
-	// DefaultCANVlan is the default CAN Bootstrap Vlan
-	DefaultCANVlan = 6
-	// DefaultCHNString is the Default CHN String
-	DefaultCHNString = "10.104.7.0/24"
-	// DefaultCHNVlan is the default CHN Bootstrap Vlan
-	DefaultCHNVlan = 5
-	// DefaultMTLString is the Default MTL String (bond0 interface)
-	DefaultMTLString = "10.1.1.0/16"
-)
-
-// DefaultCabinetMask is the default subnet mask for each cabinet
-var DefaultCabinetMask = net.CIDRMask(
-	22,
-	32,
-)
-
-// DefaultNetworkingHardwareMask is the default subnet mask for a subnet that contains all networking hardware
-var DefaultNetworkingHardwareMask = net.CIDRMask(
-	24,
-	32,
-)
-
-// DefaultLoadBalancerNMN is a thing we need
-var DefaultLoadBalancerNMN = networking.IPV4Network{
-	FullName: "Node Management Network LoadBalancers",
-	CIDR:     DefaultNMNLBString,
-	Name:     "NMNLB",
-	MTU:      9000,
-	NetType:  "ethernet",
-	Comment:  "",
-}
-
-// DefaultLoadBalancerHMN is a thing we need
-var DefaultLoadBalancerHMN = networking.IPV4Network{
-	FullName: "Hardware Management Network LoadBalancers",
-	CIDR:     DefaultHMNLBString,
-	Name:     "HMNLB",
-	MTU:      9000,
-	NetType:  "ethernet",
-	Comment:  "",
-}
-
-// DefaultBICAN is the default structure for templating the initial BICAN toggle - CMN
-var DefaultBICAN = networking.IPV4Network{
-	FullName:           "SystemDefaultRoute points the network name of the default route",
-	CIDR:               "0.0.0.0/0",
-	Name:               "BICAN",
-	VlanRange:          []int16{0},
-	MTU:                9000,
-	NetType:            "ethernet",
-	Comment:            "",
-	SystemDefaultRoute: "",
-}
-
-// DefaultHSN is the default structure for templating initial HSN configuration
-var DefaultHSN = networking.IPV4Network{
-	FullName: "High Speed Network",
-	CIDR:     DefaultHSNString,
-	Name:     "HSN",
-	VlanRange: []int16{
-		613,
-		868,
-	},
-	MTU:     9000,
-	NetType: "slingshot10",
-	Comment: "",
-}
-
-// DefaultCMN is the default structure for templating initial CMN configuration
-var DefaultCMN = networking.IPV4Network{
-	FullName:     "Customer Management Network",
-	CIDR:         DefaultCMNString,
-	Name:         "CMN",
-	VlanRange:    []int16{DefaultCMNVlan},
-	MTU:          9000,
-	NetType:      "ethernet",
-	Comment:      "",
-	ParentDevice: "bond0",
-}
-
-// DefaultCAN is the default structure for templating initial CAN configuration
-var DefaultCAN = networking.IPV4Network{
-	FullName:     "Customer Access Network",
-	CIDR:         DefaultCANString,
-	Name:         "CAN",
-	VlanRange:    []int16{DefaultCANVlan},
-	MTU:          9000,
-	NetType:      "ethernet",
-	Comment:      "",
-	ParentDevice: "bond0",
-}
-
-// DefaultCHN is the default structure for templating initial CHN configuration
-var DefaultCHN = networking.IPV4Network{
-	FullName:     "Customer High-Speed Network",
-	CIDR:         DefaultCHNString,
-	Name:         "CHN",
-	VlanRange:    []int16{DefaultCHNVlan},
-	MTU:          9000,
-	NetType:      "ethernet",
-	Comment:      "",
-	ParentDevice: "bond0",
-}
-
-// DefaultHMN is the default structure for templating initial HMN configuration
-var DefaultHMN = networking.IPV4Network{
-	FullName:     "Hardware Management Network",
-	CIDR:         DefaultHMNString,
-	Name:         "HMN",
-	VlanRange:    []int16{DefaultHMNVlan},
-	MTU:          9000,
-	NetType:      "ethernet",
-	Comment:      "",
-	ParentDevice: "bond0",
-}
-
-// DefaultNMN is the default structure for templating initial NMN configuration
-var DefaultNMN = networking.IPV4Network{
-	FullName:     "Node Management Network",
-	CIDR:         DefaultNMNString,
-	Name:         "NMN",
-	VlanRange:    []int16{DefaultNMNVlan},
-	MTU:          9000,
-	NetType:      "ethernet",
-	Comment:      "",
-	ParentDevice: "bond0",
-}
-
-// DefaultMTL is the default structure for templating initial MTL configuration
-var DefaultMTL = networking.IPV4Network{
-	FullName:     "Provisioning Network (untagged)",
-	CIDR:         DefaultMTLString,
-	Name:         "MTL",
-	VlanRange:    []int16{DefaultMTLVlan},
-	MTU:          9000,
-	NetType:      "ethernet",
-	Comment:      "This network is only valid for the NCNs",
-	ParentDevice: "bond0",
-}
-
 // GenDefaultBICANConfig returns the set of defaults for mapping the BICAN toggle
 func GenDefaultBICANConfig(systemDefaultRoute string) NetworkLayoutConfiguration {
 
-	DefaultBICAN.SystemDefaultRoute = systemDefaultRoute
+	networking.DefaultBICAN.SystemDefaultRoute = systemDefaultRoute
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultBICAN,
+		Template:                        networking.DefaultBICAN,
 		SubdivideByCabinet:              false,
 		IncludeBootstrapDHCP:            false,
 		IncludeNetworkingHardwareSubnet: false,
@@ -268,15 +74,15 @@ func GenDefaultBICANConfig(systemDefaultRoute string) NetworkLayoutConfiguration
 func GenDefaultHMNConfig() NetworkLayoutConfiguration {
 
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultHMN,
+		Template:                        networking.DefaultHMN,
 		SubdivideByCabinet:              false,
 		GroupNetworksByCabinetType:      true,
 		IncludeBootstrapDHCP:            true,
 		IncludeNetworkingHardwareSubnet: true,
 		SuperNetHack:                    true,
 		IncludeUAISubnet:                false,
-		CabinetCIDR:                     DefaultCabinetMask,
-		NetworkingHardwareNetmask:       DefaultNetworkingHardwareMask,
+		CabinetCIDR:                     networking.DefaultCabinetMask,
+		NetworkingHardwareNetmask:       networking.DefaultNetworkingHardwareMask,
 		DesiredBootstrapDHCPMask: net.CIDRMask(
 			24,
 			32,
@@ -287,15 +93,15 @@ func GenDefaultHMNConfig() NetworkLayoutConfiguration {
 // GenDefaultNMNConfig returns the set of defaults for mapping the NMN
 func GenDefaultNMNConfig() NetworkLayoutConfiguration {
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultNMN,
+		Template:                        networking.DefaultNMN,
 		SubdivideByCabinet:              false,
 		GroupNetworksByCabinetType:      true,
 		IncludeBootstrapDHCP:            true,
 		IncludeNetworkingHardwareSubnet: true,
 		SuperNetHack:                    true,
 		IncludeUAISubnet:                true,
-		CabinetCIDR:                     DefaultCabinetMask,
-		NetworkingHardwareNetmask:       DefaultNetworkingHardwareMask,
+		CabinetCIDR:                     networking.DefaultCabinetMask,
+		NetworkingHardwareNetmask:       networking.DefaultNetworkingHardwareMask,
 		DesiredBootstrapDHCPMask: net.CIDRMask(
 			24,
 			32,
@@ -307,7 +113,7 @@ func GenDefaultNMNConfig() NetworkLayoutConfiguration {
 func GenDefaultHSNConfig() NetworkLayoutConfiguration {
 
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultHSN,
+		Template:                        networking.DefaultHSN,
 		SubdivideByCabinet:              false,
 		IncludeBootstrapDHCP:            false,
 		IncludeNetworkingHardwareSubnet: false,
@@ -317,7 +123,7 @@ func GenDefaultHSNConfig() NetworkLayoutConfiguration {
 
 // GenDefaultCMNConfig returns the set of defaults for mapping the CMN
 func GenDefaultCMNConfig(ncns int, switches int) NetworkLayoutConfiguration {
-	_, cmnNet, _ := net.ParseCIDR(DefaultCMN.CIDR)
+	_, cmnNet, _ := net.ParseCIDR(networking.DefaultCMN.CIDR)
 
 	// Dynamically calculate the bootstrap_dhcp netmask based on number of NCNs.
 	bootstrapSubnet, err := networking.SubnetWithin(
@@ -328,7 +134,7 @@ func GenDefaultCMNConfig(ncns int, switches int) NetworkLayoutConfiguration {
 		log.Fatalf(
 			"Failed to find a suitable subnet mask for %d NCNs within %v\n",
 			ncns,
-			DefaultCMN.Name,
+			networking.DefaultCMN.Name,
 		)
 	}
 
@@ -341,12 +147,12 @@ func GenDefaultCMNConfig(ncns int, switches int) NetworkLayoutConfiguration {
 		log.Fatalf(
 			"Failed to find a suitable subnet mask for %d switches within %v\n",
 			switches,
-			DefaultCMN.Name,
+			networking.DefaultCMN.Name,
 		)
 	}
 
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultCMN,
+		Template:                        networking.DefaultCMN,
 		SubdivideByCabinet:              false,
 		SuperNetHack:                    true,
 		IncludeBootstrapDHCP:            true,
@@ -361,7 +167,7 @@ func GenDefaultCMNConfig(ncns int, switches int) NetworkLayoutConfiguration {
 func GenDefaultCANConfig() NetworkLayoutConfiguration {
 
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultCAN,
+		Template:                        networking.DefaultCAN,
 		SubdivideByCabinet:              false,
 		SuperNetHack:                    false,
 		IncludeBootstrapDHCP:            true,
@@ -378,7 +184,7 @@ func GenDefaultCANConfig() NetworkLayoutConfiguration {
 func GenDefaultCHNConfig() NetworkLayoutConfiguration {
 
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultCHN,
+		Template:                        networking.DefaultCHN,
 		SubdivideByCabinet:              false,
 		SuperNetHack:                    false,
 		IncludeBootstrapDHCP:            true,
@@ -395,13 +201,13 @@ func GenDefaultCHNConfig() NetworkLayoutConfiguration {
 func GenDefaultMTLConfig() NetworkLayoutConfiguration {
 
 	return NetworkLayoutConfiguration{
-		Template:                        DefaultMTL,
+		Template:                        networking.DefaultMTL,
 		SubdivideByCabinet:              false,
 		SuperNetHack:                    true,
 		IncludeBootstrapDHCP:            true,
 		IncludeNetworkingHardwareSubnet: true,
 		IncludeUAISubnet:                false,
-		NetworkingHardwareNetmask:       DefaultNetworkingHardwareMask,
+		NetworkingHardwareNetmask:       networking.DefaultNetworkingHardwareMask,
 		DesiredBootstrapDHCPMask: net.CIDRMask(
 			24,
 			32,
@@ -447,7 +253,7 @@ func BuildCSMNetworks(
 	//
 	// Start the NMN Load Balancer with our Defaults
 	//
-	tempNMNLoadBalancer := DefaultLoadBalancerNMN
+	tempNMNLoadBalancer := networking.DefaultLoadBalancerNMN
 	// Add a /24 for the Load Balancers
 	pool, _ := tempNMNLoadBalancer.AddSubnet(
 		net.CIDRMask(
@@ -474,7 +280,7 @@ func BuildCSMNetworks(
 	//
 	// Start the HMN Load Balancer with our Defaults
 	//
-	tempHMNLoadBalancer := DefaultLoadBalancerHMN
+	tempHMNLoadBalancer := networking.DefaultLoadBalancerHMN
 	pool, _ = tempHMNLoadBalancer.AddSubnet(
 		net.CIDRMask(
 			24,
@@ -731,7 +537,7 @@ func createNetFromLayoutConfig(conf NetworkLayoutConfiguration) (*networking.IPV
 			subnet, err := tempNet.AddSubnetbyCIDR(
 				*hsnDefaultSubnet,
 				"hsn_base_subnet",
-				int16(DefaultHSN.VlanRange[0]),
+				int16(networking.DefaultHSN.VlanRange[0]),
 			)
 			if err != nil {
 				log.Fatalf(

--- a/pkg/networking/network.go
+++ b/pkg/networking/network.go
@@ -37,7 +37,6 @@ import (
 	"github.com/Cray-HPE/cray-site-init/pkg/cli"
 )
 
-
 const (
 	// DefaultMTLVlan is the default MTL Bootstrap Vlan - zero (0) represents untagged.
 	DefaultMTLVlan = 1
@@ -82,7 +81,6 @@ const (
 	// DefaultMTLString is the Default MTL String (bond0 interface)
 	DefaultMTLString = "10.1.1.0/16"
 )
-
 
 /*
 Handy Netmask Cheet Sheet
@@ -232,7 +230,6 @@ var DefaultMTL = IPV4Network{
 	Comment:      "This network is only valid for the NCNs",
 	ParentDevice: "bond0",
 }
-
 
 // IPV4Network is a type for managing IPv4 Networks
 type IPV4Network struct {

--- a/pkg/networking/network.go
+++ b/pkg/networking/network.go
@@ -682,7 +682,9 @@ func (iSubnet *IPV4Subnet) GenInterfaceName() error {
 			iSubnet.NetName,
 		)
 	}
-	if iSubnet.VlanID < 1 {
+
+	// TODO - Vlans below should come out of sls Defaults, but have circular deps
+	if iSubnet.VlanID == 0 || iSubnet.VlanID == 1 {
 		iSubnet.InterfaceName = fmt.Sprintf(
 			"%s",
 			iSubnet.ParentDevice,

--- a/pkg/networking/network.go
+++ b/pkg/networking/network.go
@@ -26,6 +26,7 @@ package networking
 
 import (
 	"fmt"
+	"github.com/Cray-HPE/cray-site-init/pkg/sls"
 	"log"
 	"net"
 	"strings"
@@ -34,8 +35,204 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Cray-HPE/cray-site-init/pkg/cli"
-	"github.com/Cray-HPE/cray-site-init/pkg/sls"
 )
+
+
+const (
+	// DefaultMTLVlan is the default MTL Bootstrap Vlan - zero (0) represents untagged.
+	DefaultMTLVlan = 1
+	// DefaultHMNString is the Default HMN String (bond0.hmn0)
+	DefaultHMNString = "10.254.0.0/17"
+	// DefaultHMNVlan is the default HMN Bootstrap Vlan
+	DefaultHMNVlan = 4
+	// DefaultHMNMTNString is the default HMN Network for Mountain Cabinets with Grouped Configuration
+	DefaultHMNMTNString = "10.104.0.0/17"
+	// DefaultHMNRVRString is the default HMN Network for River Cabinets with Grouped Configuration
+	DefaultHMNRVRString = "10.107.0.0/17"
+	// DefaultNMNString is the Default NMN String (bond0.nmn0)
+	DefaultNMNString = "10.252.0.0/17"
+	// DefaultNMNVlan is the default NMN Bootstrap Vlan
+	DefaultNMNVlan = 2
+	// DefaultMacVlanVlan is the default MacVlan Bootstrap Vlan
+	DefaultMacVlanVlan = 2
+	// DefaultNMNMTNString is the default NMN Network for Mountain Cabinets with Grouped Configuration
+	DefaultNMNMTNString = "10.100.0.0/17"
+	// DefaultNMNRVRString is the default NMN Network for River Cabinets with Grouped Configuration
+	DefaultNMNRVRString = "10.106.0.0/17"
+	// DefaultNMNLBString is the default LoadBalancer CIDR for the NMN
+	DefaultNMNLBString = "10.92.100.0/24"
+	// DefaultHMNLBString is the default LoadBalancer CIDR for the HMN
+	DefaultHMNLBString = "10.94.100.0/24"
+	// DefaultMacVlanString is the default Macvlan cidr (shares vlan with NMN)
+	DefaultMacVlanString = "10.252.124.0/23"
+	// DefaultHSNString is the Default HSN String
+	DefaultHSNString = "10.253.0.0/16"
+	// DefaultCMNString is the Default CMN String (bond0.cmn0)
+	DefaultCMNString = "10.103.6.0/24"
+	// DefaultCMNVlan is the default CMN Bootstrap Vlan
+	DefaultCMNVlan = 7
+	// DefaultCANString is the Default CAN String (bond0.can0)
+	DefaultCANString = "10.102.11.0/24"
+	// DefaultCANVlan is the default CAN Bootstrap Vlan
+	DefaultCANVlan = 6
+	// DefaultCHNString is the Default CHN String
+	DefaultCHNString = "10.104.7.0/24"
+	// DefaultCHNVlan is the default CHN Bootstrap Vlan
+	DefaultCHNVlan = 5
+	// DefaultMTLString is the Default MTL String (bond0 interface)
+	DefaultMTLString = "10.1.1.0/16"
+)
+
+
+/*
+Handy Netmask Cheet Sheet
+/30	4	2	255.255.255.252	1/64
+/29	8	6	255.255.255.248	1/32
+/28	16	14	255.255.255.240	1/16
+/27	32	30	255.255.255.224	1/8
+/26	64	62	255.255.255.192	1/4
+/25	128	126	255.255.255.128	1/2
+/24	256	254	255.255.255.0	1
+/23	512	510	255.255.254.0	2
+/22	1024	1022	255.255.252.0	4
+/21	2048	2046	255.255.248.0	8
+/20	4096	4094	255.255.240.0	16
+/19	8192	8190	255.255.224.0	32
+/18	16384	16382	255.255.192.0	64
+/17	32768	32766	255.255.128.0	128
+/16	65536	65534	255.255.0.0	256
+*/
+
+// DefaultCabinetMask is the default subnet mask for each cabinet
+var DefaultCabinetMask = net.CIDRMask(
+	22,
+	32,
+)
+
+// DefaultNetworkingHardwareMask is the default subnet mask for a subnet that contains all networking hardware
+var DefaultNetworkingHardwareMask = net.CIDRMask(
+	24,
+	32,
+)
+
+// DefaultLoadBalancerNMN is a thing we need
+var DefaultLoadBalancerNMN = IPV4Network{
+	FullName: "Node Management Network LoadBalancers",
+	CIDR:     DefaultNMNLBString,
+	Name:     "NMNLB",
+	MTU:      9000,
+	NetType:  "ethernet",
+	Comment:  "",
+}
+
+// DefaultLoadBalancerHMN is a thing we need
+var DefaultLoadBalancerHMN = IPV4Network{
+	FullName: "Hardware Management Network LoadBalancers",
+	CIDR:     DefaultHMNLBString,
+	Name:     "HMNLB",
+	MTU:      9000,
+	NetType:  "ethernet",
+	Comment:  "",
+}
+
+// DefaultBICAN is the default structure for templating the initial BICAN toggle - CMN
+var DefaultBICAN = IPV4Network{
+	FullName:           "SystemDefaultRoute points the network name of the default route",
+	CIDR:               "0.0.0.0/0",
+	Name:               "BICAN",
+	VlanRange:          []int16{0},
+	MTU:                9000,
+	NetType:            "ethernet",
+	Comment:            "",
+	SystemDefaultRoute: "",
+}
+
+// DefaultHSN is the default structure for templating initial HSN configuration
+var DefaultHSN = IPV4Network{
+	FullName: "High Speed Network",
+	CIDR:     DefaultHSNString,
+	Name:     "HSN",
+	VlanRange: []int16{
+		613,
+		868,
+	},
+	MTU:     9000,
+	NetType: "slingshot10",
+	Comment: "",
+}
+
+// DefaultCMN is the default structure for templating initial CMN configuration
+var DefaultCMN = IPV4Network{
+	FullName:     "Customer Management Network",
+	CIDR:         DefaultCMNString,
+	Name:         "CMN",
+	VlanRange:    []int16{DefaultCMNVlan},
+	MTU:          9000,
+	NetType:      "ethernet",
+	Comment:      "",
+	ParentDevice: "bond0",
+}
+
+// DefaultCAN is the default structure for templating initial CAN configuration
+var DefaultCAN = IPV4Network{
+	FullName:     "Customer Access Network",
+	CIDR:         DefaultCANString,
+	Name:         "CAN",
+	VlanRange:    []int16{DefaultCANVlan},
+	MTU:          9000,
+	NetType:      "ethernet",
+	Comment:      "",
+	ParentDevice: "bond0",
+}
+
+// DefaultCHN is the default structure for templating initial CHN configuration
+var DefaultCHN = IPV4Network{
+	FullName:     "Customer High-Speed Network",
+	CIDR:         DefaultCHNString,
+	Name:         "CHN",
+	VlanRange:    []int16{DefaultCHNVlan},
+	MTU:          9000,
+	NetType:      "ethernet",
+	Comment:      "",
+	ParentDevice: "bond0",
+}
+
+// DefaultHMN is the default structure for templating initial HMN configuration
+var DefaultHMN = IPV4Network{
+	FullName:     "Hardware Management Network",
+	CIDR:         DefaultHMNString,
+	Name:         "HMN",
+	VlanRange:    []int16{DefaultHMNVlan},
+	MTU:          9000,
+	NetType:      "ethernet",
+	Comment:      "",
+	ParentDevice: "bond0",
+}
+
+// DefaultNMN is the default structure for templating initial NMN configuration
+var DefaultNMN = IPV4Network{
+	FullName:     "Node Management Network",
+	CIDR:         DefaultNMNString,
+	Name:         "NMN",
+	VlanRange:    []int16{DefaultNMNVlan},
+	MTU:          9000,
+	NetType:      "ethernet",
+	Comment:      "",
+	ParentDevice: "bond0",
+}
+
+// DefaultMTL is the default structure for templating initial MTL configuration
+var DefaultMTL = IPV4Network{
+	FullName:     "Provisioning Network (untagged)",
+	CIDR:         DefaultMTLString,
+	Name:         "MTL",
+	VlanRange:    []int16{DefaultMTLVlan},
+	MTU:          9000,
+	NetType:      "ethernet",
+	Comment:      "This network is only valid for the NCNs",
+	ParentDevice: "bond0",
+}
+
 
 // IPV4Network is a type for managing IPv4 Networks
 type IPV4Network struct {
@@ -684,7 +881,7 @@ func (iSubnet *IPV4Subnet) GenInterfaceName() error {
 	}
 
 	// TODO - Vlans below should come out of sls Defaults, but have circular deps
-	if iSubnet.VlanID == 0 || iSubnet.VlanID == 1 {
+	if iSubnet.VlanID == 0 || iSubnet.VlanID == DefaultMTLVlan {
 		iSubnet.InterfaceName = fmt.Sprintf(
 			"%s",
 			iSubnet.ParentDevice,


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [MTL-2437](https://jira-pro.it.hpe.com:8443/browse/MTL-2437)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
MTL-2437 prevented VLAN re-use and duplication.  Previous to that change both BICAN and MTL used VLAN 0.  This, for several reasons, is wrong.  MTL-2437 changed the default MTL VLAN to 1 from 0, which had no downstream impact on CANU or switch configs.  However, VLAN 0 was hard coded in `ifcfg` file generation and `dnsmasq` file generation so the change in MTL VLANs broke the PIT interfaces (both `bond0` and `bond0.mtl0` were IP'd with the same IP address.  Additionally, a dnsmasq file was generated for `bond0.mtl0` which is erroneous.

This change fixes the problem in two ways. First the MTL VLAN variable is used in `ifcfg` file generation.  Second, because of circular dependencies the `dnsmasq` file generation code adds VLAN 1 to the existing VLAN 0.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
Tested on `surtur` by performing an end to end install using `csi config init` output generated using this change.
* All NCNs deployed without issue and validation checks passed
* CSM services installed without issue and validation checks passed
* Final NCN was also successfully booted into the cluster

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
The internal test system repository was used with several runs across each system.  
 
### Risks and Mitigations

In a future change the `dnsmasq` VLAN hard coding should be removed with something far more intelligent.  In practice there is no way to change MTL from VLAN 1 so the existing code will work unless the default MTL VLAN is changed in code and CSI is recompiled.

