### PR TITLE
MTL-2484 - Remove kube-api from all but NMN

### DIFF
--- a/pkg/cli/config/initialize/sls/networkBuilder.go
+++ b/pkg/cli/config/initialize/sls/networkBuilder.go
@@ -628,14 +628,14 @@ func createNetFromLayoutConfig(conf NetworkLayoutConfiguration) (*networking.IPV
 						[]string{},
 					)
 				}
-				subnet.AddReservation(
-					"kubeapi-vip",
-					"k8s-virtual-ip",
-				)
 				if tempNet.Name == "NMN" {
 					subnet.AddReservation(
 						"rgw-vip",
 						"rgw-virtual-ip",
+					)
+					subnet.AddReservation(
+						"kubeapi-vip",
+						"k8s-virtual-ip",
 					)
 				}
 			}


### PR DESCRIPTION
### Summary and Scope

- Fixes: [MTL-2484](https://jira-pro.it.hpe.com:8443/browse/MTL-2484)

#### Issue Type

- Bugfix Pull Request
 
The `kubeapi-vip` only exists on the NMN however records for it get generated in other SLS networks resulting in DNS entries for services that don't exist.

This PR removes `kubeapi-vip` from all networks other than the NMN 

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

Tested using local data

Old behaviour

```bash
$ jq -c '.Networks | to_entries[] | {"Network":.key, "VIP": .value.ExtraProperties.Subnets[] | select(.FullName|contains("Bootstrap")) | .IPReservations[] | select(.Name=="kubeapi-vip")}' sls_input_file.json
{"Network":"CHN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.102.193.196","Comment":"k8s-virtual-ip"}}
{"Network":"CMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.102.193.18","Comment":"k8s-virtual-ip"}}
{"Network":"HMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.254.1.2","Comment":"k8s-virtual-ip"}}
{"Network":"NMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.252.1.2","Aliases":["kubeapi-vip.local"],"Comment":"k8s-virtual-ip"}}
```

New behaviour

```bash
$ jq -c '.Networks | to_entries[] | {"Network":.key, "VIP": .value.ExtraProperties.Subnets[] | select(.FullName|contains("Bootstrap")) | .IPReservations[] | select(.Name=="kubeapi-vip")}' sls_input_file.json
{"Network":"NMN","VIP":{"Name":"kubeapi-vip","IPAddress":"10.252.1.3","Aliases":["kubeapi-vip.local"],"Comment":"k8s-virtual-ip"}}
```
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
