### PR TITLE
Support any major version and optional `v`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
       - '*'
     tags:
       # semver tags:
-      - 'v[12].[0-9]+.[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - '*'
     tags:
       # semver tags:
-      - 'v[12].[0-9]+.[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The regexes for our workflows were inconsistent with one another.

They should be the same, and not limit themselves to `1.x.y` and `2.x.y`.
