### PR TITLE
CASMNET-2212 - Switch to install Cilium by default (not weave) in cloud-init

### DIFF
--- a/pkg/cli/config/initialize/basecamp.go
+++ b/pkg/cli/config/initialize/basecamp.go
@@ -114,7 +114,7 @@ type BaseCampGlobals struct {
 	KubernetesServicesCIDR     string `json:"kubernetes-services-cidr"`      // "10.16.0.0/12"
 	KubernetesWeaveMTU         string `json:"kubernetes-weave-mtu"`          // 1376
 	KubernetesCiliumOpReplicas string `json:"cilium-operator-replicas"`      // 1
-	KubernetesPrimaryCNI       string `json:"k8s-primary-cni"`               // weave
+	KubernetesPrimaryCNI       string `json:"k8s-primary-cni"`               // cilium
 	KubernetesKubeProxyReplace string `json:"cilium-kube-proxy-replacement"` // disabled
 
 	NumStorageNodes int `json:"num_storage_nodes"`
@@ -171,7 +171,7 @@ var basecampGlobalString = `{
 	"kubernetes-services-cidr": "10.16.0.0/12",
 	"kubernetes-weave-mtu": "1376",
 	"cilium-operator-replicas": "1",
-	"k8s-primary-cni": "weave",
+	"k8s-primary-cni": "cilium",
 	"cilium-kube-proxy-replacement": "disabled",
 	"rgw-virtual-ip": "~FIXME~ e.g. 10.252.2.100",
 	"wipe-ceph-osds": "yes",


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMNET-2212](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2212)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

CSM 1.7 will use the Cilium container network interface. This PR makes Cilium the default CNI for a fresh install.

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [X] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
Tested using data from wasp. Cilium is now the default CNI in the basecamp data.json file.

```
$ csi config init
...
2025/02/25 17:10:09 Detected CSM v1.7, setting k8s-primary-cni to Cilium
...

$ jq '.Global."meta-data"."k8s-primary-cni"' wasp/basecamp/data.json
"cilium"
```

### Idempotency

If CSM version is < 1.7 then default to `weave` 

#### CSM 1.6
```
$ csi config init --csm-version 1.6
...

$ jq '.Global."meta-data"."k8s-primary-cni"' wasp/basecamp/data.json
"weave"
```
#### CSM 1.5
```
$ csi config init --csm-version 1.5
...

$ jq '.Global."meta-data"."k8s-primary-cni"' wasp/basecamp/data.json
"weave"
```
####  CSM 1.4
```
$ csi config init --csm-version 1.4
...
$ jq '.Global."meta-data"."k8s-primary-cni"' wasp/basecamp/data.json
"weave"
 ```
### Risks and Mitigations

The old value is still selectable by editing `data.json` before commencing the deployment of NCNs however we do not want to support Weave going forward so this parameter is not exposed via a CLI or config option.
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
