### PR TITLE
CASMNET-2318 - Add switch and network information to MetalLB data

### DIFF
--- a/pkg/cli/config/initialize/initialize.go
+++ b/pkg/cli/config/initialize/initialize.go
@@ -1443,12 +1443,16 @@ func writeOutput(
 		),
 		logicalNCNs,
 	)
-	WriteMetalLBConfigMap(
-		basepath,
-		v,
-		shastaNetworks,
-		switches,
-	)
+	// The MetalLB ConfigMap is no longer used in CSM 1.7
+	_, eval := csm.CompareMajorMinor("1.7")
+	if eval == -1 {
+		WriteMetalLBConfigMap(
+			basepath,
+			v,
+			shastaNetworks,
+			switches,
+		)
+	}
 	WriteBasecampData(
 		filepath.Join(
 			basepath,

--- a/pkg/cli/config/initialize/metallb.go
+++ b/pkg/cli/config/initialize/metallb.go
@@ -71,6 +71,8 @@ type PeerDetail struct {
 	IPAddress string `yaml:"peer-address" valid:"_,required"`
 	PeerASN   int    `yaml:"peer-asn" valid:"_,required"`
 	MyASN     int    `yaml:"my-asn" valid:"_,required"`
+	Name      string `yaml:"device-name" valid:"_,required"`
+	Network   string `yaml:"device-network" valid:"_,required"`
 }
 
 // AddressPoolDetail holds information about each of the MetalLB address pools
@@ -112,6 +114,8 @@ func GetMetalLBConfig(
 					tmpPeer.PeerASN = network.PeerASN
 					tmpPeer.MyASN = network.MyASN
 					tmpPeer.IPAddress = reservation.IPAddress.String()
+					tmpPeer.Name = reservation.Name
+					tmpPeer.Network = strings.ToLower(name)
 					if spineSwitchNameRegexp.FindString(reservation.Name) != "" {
 						configStruct.SpineSwitches = append(
 							configStruct.SpineSwitches,
@@ -132,6 +136,8 @@ func GetMetalLBConfig(
 					tmpPeer.PeerASN = network.PeerASN
 					tmpPeer.MyASN = network.MyASN
 					tmpPeer.IPAddress = reservation.IPAddress.String()
+					tmpPeer.Name = reservation.Name
+					tmpPeer.Network = strings.ToLower(name)
 					if edgeSwitchNameRegexp.FindString(reservation.Name) != "" {
 						configStruct.EdgeSwitches = append(
 							configStruct.EdgeSwitches,


### PR DESCRIPTION
### Summary and Scope

The version of MetalLB used in all current versions of CSM is old and configured by means of a Kubernetes ConfigMap.

Newer versions of MetalLB are configured by means of Custom Resource Definitions (IPAddressPool, BGPPeer, BGPAdvertisement).

```
ncn-m001:~ # kubectl -n metallb-system get bgpadvertisements.metallb.io
NAME                  IPADDRESSPOOLS                                         IPADDRESSPOOL SELECTORS   PEERS
customer-high-speed   ["customer-high-speed"]                                                          ["sw-edge-001"]
customer-management   ["customer-management-static","customer-management"]                             ["sw-spine-001-cmn","sw-spine-002-cmn"]
node-management       ["node-management","hardware-management"]                                        ["sw-spine-001-nmn","sw-spine-002-nmn"]
```

The data that csi generates in customizations.yaml does not have enough information to allow a BGPAdvertisement to be created that maps an IPAddressPool to a BGPPeer. This PR adds the switch name and the CSM network the switch resides on to the output data.

- Fixes: [CASMNET-2318](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2318)
- Relates to: [CASMPET-7388](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7388)

⚠️ This PR must be merged with [CASMPET-7388](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7388) and not before as the extra fields are not compatible with the older version of MetalLB that is currently still in CSM 1.7. These fields are not generated when `csm-version` is 1.6 or lower to avoid backwards compatibility issues with earlier releases.

#### Issue Type

- RFE Pull Request

### Prerequisites

- [X] I have included documentation in my PR (or it is not required)
- [X] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
Tested using data from system `wasp`

#### `csm-version` set to 1.7

```
$ grep csm-version system_config.yaml
csm-version: 1.7

$ ./csi config init
2025/04/03 12:17:26 CSM installation or upgrade presence is unknown; CSM_RELEASE was not found in the environment
2025/04/03 12:17:26 [csm-version] was set to [v1.7]; All inputs are targeted for CSM v1.7
```

New fields are present in `customizations.yaml`

```
$ yq .network.metallb wasp/customizations.yaml
peers:
  - peer-address: 10.252.0.2
    peer-asn: 65533
    my-asn: 65531
    device-name: sw-spine-001
    device-network: nmn
  - peer-address: 10.252.0.3
    peer-asn: 65533
    my-asn: 65531
    device-name: sw-spine-002
    device-network: nmn
  - peer-address: 10.102.167.2
    peer-asn: 65533
    my-asn: 65532
    device-name: sw-spine-001
    device-network: cmn
  - peer-address: 10.102.167.3
    peer-asn: 65533
    my-asn: 65532
    device-name: sw-spine-002
    device-network: cmn
  - peer-address: 10.102.167.194
    peer-asn: 65533
    my-asn: 65530
    device-name: chn-switch-1
    device-network: chn
address-pools:
  - name: customer-high-speed
    protocol: bgp
    addresses:
      - 10.102.167.224/27
  - name: customer-management-static
    protocol: bgp
    addresses:
      - 10.102.167.60/30
  - name: customer-management
    protocol: bgp
    addresses:
      - 10.102.167.64/26
  - name: node-management
    protocol: bgp
    addresses:
      - 10.92.100.0/24
  - name: hardware-management
    protocol: bgp
    addresses:
      - 10.94.100.0/24
```

The MetalLB ConfigMap file does not exist

```
$ ls -l wasp/metallb.yaml
ls: wasp/metallb.yaml: No such file or directory
```

#### `csm-version` set to 1.6

```
$ grep csm-version system_config.yaml
csm-version: 1.6

$ ./csi config init
2025/04/03 12:18:56 CSM installation or upgrade presence is unknown; CSM_RELEASE was not found in the environment
2025/04/03 12:18:56 [csm-version] was set to [v1.6]; All inputs are targeted for CSM v1.6
...
```

The new fields that were added are not present
```
$ yq .network.metallb wasp/customizations.yaml
peers:
  - peer-address: 10.102.167.2
    peer-asn: 65533
    my-asn: 65532
  - peer-address: 10.102.167.3
    peer-asn: 65533
    my-asn: 65532
  - peer-address: 10.252.0.2
    peer-asn: 65533
    my-asn: 65531
  - peer-address: 10.252.0.3
    peer-asn: 65533
    my-asn: 65531
  - peer-address: 10.102.167.194
    peer-asn: 65533
    my-asn: 65530
address-pools:
  - name: customer-high-speed
    protocol: bgp
    addresses:
      - 10.102.167.224/27
  - name: node-management
    protocol: bgp
    addresses:
      - 10.92.100.0/24
  - name: customer-management-static
    protocol: bgp
    addresses:
      - 10.102.167.60/30
  - name: customer-management
    protocol: bgp
    addresses:
      - 10.102.167.64/26
  - name: hardware-management
    protocol: bgp
    addresses:
      - 10.94.100.0/24
```

The MetalLB ConfigMap is generated

```
$ ls -l wasp/metallb.yaml
-rw-r--r--@ 1 cspiller  staff  1034  3 Apr 12:18 wasp/metallb.yaml
```

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
