### PR TITLE
CASMINST-7395 Omit recently added flags

### DIFF
--- a/pkg/cli/config/initialize/write.go
+++ b/pkg/cli/config/initialize/write.go
@@ -36,8 +36,11 @@ var DeprecatedKeys []string
 // NoWriteKeys are keys that shouldn't be written to a config file.
 var NoWriteKeys = []string{
 	"config",
+	"csm-api-url",
 	"help",
 	"input-dir",
+	"k8s-namespace",
+	"k8s-secret-name",
 }
 
 var Aliases []string


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-7395
- Relates to: #488 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request

<!--- words; describe what this change is and what it is for. -->
The new flags, `csm-api-url`, `k8s-namespace`, and `k8s-secret-name` were not intended to be included in generated `system_config.yaml` files. This could be reconsidered, but they are primarily for development. If these are set, it could throw off a CSM install if they went unnoticed.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
