### PR TITLE
CASMINST-7396 null global userdata

### DIFF
--- a/pkg/cli/config/initialize/initialize.go
+++ b/pkg/cli/config/initialize/initialize.go
@@ -403,7 +403,7 @@ func NewCommand() *cobra.Command {
 					*ncn,
 				)
 			}
-			globals, err := MakeBasecampGlobals(
+			globalMetaData, err := MakeBasecampGlobalMetaData(
 				v,
 				ncns,
 				shastaNetworks,
@@ -413,7 +413,7 @@ func NewCommand() *cobra.Command {
 			)
 			if err != nil {
 				log.Fatalln(
-					"unable to generate basecamp globals: ",
+					"unable to generate basecamp globalMetaData: ",
 					err,
 				)
 			}
@@ -423,7 +423,7 @@ func NewCommand() *cobra.Command {
 				slsState,
 				ncns,
 				switches,
-				globals,
+				globalMetaData,
 			)
 			if err != nil {
 				log.Fatalf(
@@ -1510,7 +1510,7 @@ func writeOutput(
 	slsState slsCommon.SLSState,
 	logicalNCNs []LogicalNCN,
 	switches []*networking.ManagementSwitch,
-	globals interface{},
+	globalMetaData interface{},
 ) (err error) {
 	basepath, _ := setupDirectories(
 		v.GetString("system-name"),
@@ -1632,7 +1632,7 @@ func writeOutput(
 		),
 		logicalNCNs,
 		shastaNetworks,
-		globals,
+		globalMetaData,
 	)
 	return err
 }

--- a/pkg/cli/config/initialize/pit_basecamp.go
+++ b/pkg/cli/config/initialize/pit_basecamp.go
@@ -43,9 +43,9 @@ import (
 	"github.com/Cray-HPE/cray-site-init/pkg/networking"
 )
 
-// BaseCampGlobals is the set of information needed for an install to reach
+// BasecampGlobalMetaData is the set of information needed for an install to reach
 // the handoff point.
-type BaseCampGlobals struct {
+type BasecampGlobalMetaData struct {
 	CiliumKubeProxyReplacement string      `json:"cilium-kube-proxy-replacement"`
 	CiliumOperatorReplicas     string      `json:"cilium-operator-replicas"`
 	DNSServer                  string      `json:"dns-server"`
@@ -292,9 +292,9 @@ func MakeBasecampHostRecords(
 	return hostrecords
 }
 
-// MakeBasecampGlobals uses the defaults above to create a suitable k/v pairing for the
+// MakeBasecampGlobalMetaData uses the defaults above to create a suitable k/v pairing for the
 // Globals in data.json for basecamp
-func MakeBasecampGlobals(
+func MakeBasecampGlobalMetaData(
 	v *viper.Viper,
 	logicalNcns []LogicalNCN,
 	shastaNetworks map[string]*networking.IPNetwork,
@@ -302,10 +302,10 @@ func MakeBasecampGlobals(
 	installSubnet string,
 	installNCN string,
 ) (
-	BaseCampGlobals, error,
+	BasecampGlobalMetaData, error,
 ) {
 	// Create the map to return
-	global := BaseCampGlobals{}
+	global := BasecampGlobalMetaData{}
 
 	// First loop through and see if there's a viper flag
 	// We register a few aliases because flags don't necessarily match data.json keys
@@ -709,7 +709,7 @@ func MakeBaseCampfromNCNs(
 
 // WriteBasecampData writes basecamp data.json for the installer
 func WriteBasecampData(
-	path string, ncns []LogicalNCN, shastaNetworks map[string]*networking.IPNetwork, globals interface{},
+	path string, ncns []LogicalNCN, shastaNetworks map[string]*networking.IPNetwork, globalMetaData interface{},
 ) {
 	v := viper.GetViper()
 	basecampConfig, err := MakeBaseCampfromNCNs(
@@ -724,17 +724,17 @@ func WriteBasecampData(
 		)
 	}
 	// To write this the way we want to consume it, we need to convert it to a map of strings and interfaces
-	globalJSON, err := json.Marshal(globals)
+	globalMetaDataJSON, err := json.Marshal(globalMetaData)
 	if err != nil {
 		log.Fatalf(
 			"Failed to marshal global data because %v",
 			err,
 		)
 	}
-	globalMetadata := bssTypes.CloudInit{}
+	global := bssTypes.CloudInit{}
 	err = json.Unmarshal(
-		globalJSON,
-		&globalMetadata.MetaData,
+		globalMetaDataJSON,
+		&global.MetaData,
 	)
 	if err != nil {
 		log.Fatalf(
@@ -743,7 +743,7 @@ func WriteBasecampData(
 		)
 	}
 	data := make(bssTypes.CloudDataType)
-	data["Global"] = globalMetadata
+	data["Global"] = global
 	for k, v := range basecampConfig {
 		data[k] = v
 	}

--- a/pkg/cli/config/initialize/pit_basecamp.go
+++ b/pkg/cli/config/initialize/pit_basecamp.go
@@ -731,7 +731,9 @@ func WriteBasecampData(
 			err,
 		)
 	}
-	global := bssTypes.CloudInit{}
+	global := bssTypes.CloudInit{
+		UserData: make(map[string]interface{}),
+	}
 	err = json.Unmarshal(
 		globalMetaDataJSON,
 		&global.MetaData,


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-7396
- Relates to: #488 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
VShasta runs were reporting errors when munging `Global` data, the Global entry created after #488 changed the `user-data` value from a `map` to `nil`. This change causes Vshasta runs to barf during their PIT initialization.

Example: https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm-vshasta-deploy/detail/main/2129/

This change also includes a minor refactor to make the variables more clear as to what they contain with regards to meta-data vs user-data.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
