### PR TITLE
Lint changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,14 +3,9 @@ name: Lint
 on:
   push:
     branches:
-      - '*'
-    tags:
-      # semver tags:
-      - 'v?[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches:
       - main
       - 'release/**'
+  pull_request:
 
 jobs:
 
@@ -25,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version: 1.24
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: run shellcheck
       uses: ludeeus/action-shellcheck@master
       with:


### PR DESCRIPTION
Fixes issues with the linter.

golangci-lint, when `only-new-issues` is set, only works for the main branches (post-merge) and on pull-request.

For pushes to feature branches, errors like the one below can be observed:

(excerpt from https://github.com/Cray-HPE/cray-site-init/actions/runs/16383180901/job/46298433164#step:4:23)
```
  failed to fetch push patch: RequestError [HttpError]: Not Found - https://docs.github.com/rest/commits/commits#compare-two-commits
  Prepared env in 862ms
      at /home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:44487:21
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async requestWithGraphqlErrorHandling (/home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:44213:20)
      at async Job.doExecute (/home/runner/work/_actions/golangci/golangci-lint-action/v8/dist/run/index.js:53330:18) {
    status: 404,
    response: {
      url: 'https://api.github.com/repos/Cray-HPE/cray-site-init/compare/0000000000000000000000000000000000000000...638d5e2166ef3a014b0a8e0301dee4a1ac5eaf97',
```

NOTE: the `url` in the request has an invalid commit

This results in a failed patch and causes the linter to lint the entire code base instead of the developer's changes.