### PR TITLE
Fix incorrect "new reservation" count

### DIFF
--- a/pkg/cli/patch/csm/sls.go
+++ b/pkg/cli/patch/csm/sls.go
@@ -348,7 +348,7 @@ func allocateIPReservations(slsProperties *slsCommon.NetworkExtraProperties) (er
 		fmt.Printf(
 			"%-40s : %-3d\n",
 			"** new reservations",
-			totalReservations,
+			uint(totalReservations)-skippedReservations,
 		)
 		if skippedReservations > 0 {
 			fmt.Printf(


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMINST-7408
- Relates to: CASMNET-2355

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The "new reservations" is printing the total number of reservations instead of the number of actual, new reservations. This is noticable when re-running `csi patch csm ipv6` after adding new hardware to a system.

```
* bootstrap_dhcp subnet                  ...
** new reservations                      : 15
** prior reservations                    : 14
```

The above output should say "new reservations : 1"

This fixes the output only to show the number of new reservations.

```
Adding IPv6 to CHN network               ...
* CIDR6                                  : fdf8:413:de2c:201::/64
* Gateway6                               : fdf8:413:de2c:201::1
* bootstrap_dhcp subnet                  ...
** new reservations                      : 1
** prior reservations                    : 12
Adding IPv6 to CMN network               ...
* CIDR6                                  : fdf8:413:de2c:200::/64
* Gateway6                               : fdf8:413:de2c:200::1
* network_hardware subnet                ...
** new reservations                      : 0
** prior reservations                    : 3
* bootstrap_dhcp subnet                  ...
** new reservations                      : 1
** prior reservations                    : 10
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
