### PR TITLE
CASMNET-2383 - fmn-virtual-ip is created on systems that do not have fabric manager nodes

### DIFF
--- a/pkg/cli/config/initialize/sls.go
+++ b/pkg/cli/config/initialize/sls.go
@@ -214,6 +214,16 @@ func GenerateDefaultNetworkConfigs(
 			hillCabinetCount += len(cab.CabinetIDs())
 		}
 	}
+
+	// Check if any FabricManager nodes exist in the system
+	hasFabricManagerNodes := false
+	for _, ncn := range logicalNCNs {
+		if ncn.Subrole == "FabricManager" {
+			hasFabricManagerNodes = true
+			break
+		}
+	}
+
 	defaultNetConfigs = make(map[string]slsInit.NetworkLayoutConfiguration)
 	// Prepare the network layout configs for generating the networks
 	defaultNetConfigs["BICAN"] = slsInit.GenDefaultBICANConfig(v.GetString("bican-user-network-name"))
@@ -221,10 +231,14 @@ func GenerateDefaultNetworkConfigs(
 		len(logicalNCNs),
 		len(switches),
 	)
-	defaultNetConfigs["HMN"] = slsInit.GenDefaultHMNConfig()
+	hmnConfig := slsInit.GenDefaultHMNConfig()
+	hmnConfig.HasFabricManagerNodes = hasFabricManagerNodes
+	defaultNetConfigs["HMN"] = hmnConfig
 	defaultNetConfigs["HSN"] = slsInit.GenDefaultHSNConfig()
 	defaultNetConfigs["MTL"] = slsInit.GenDefaultMTLConfig()
-	defaultNetConfigs["NMN"] = slsInit.GenDefaultNMNConfig()
+	nmnConfig := slsInit.GenDefaultNMNConfig()
+	nmnConfig.HasFabricManagerNodes = hasFabricManagerNodes
+	defaultNetConfigs["NMN"] = nmnConfig
 	if v.GetString("bican-user-network-name") == "CAN" || v.GetBool("retain-unused-user-network") {
 		defaultNetConfigs["CAN"] = slsInit.GenDefaultCANConfig()
 	}

--- a/pkg/cli/config/initialize/sls/networkBuilder.go
+++ b/pkg/cli/config/initialize/sls/networkBuilder.go
@@ -57,6 +57,7 @@ type NetworkLayoutConfiguration struct {
 	CabinetDetails                  []sls.CabinetGroupDetail
 	CabinetCIDR                     net.IPMask
 	ManagementSwitches              []*networking.ManagementSwitch
+	HasFabricManagerNodes           bool
 }
 
 // GenDefaultBICANConfig returns the set of defaults for mapping the BICAN toggle
@@ -759,9 +760,9 @@ func createNetFromLayoutConfig(conf NetworkLayoutConfiguration) (network *networ
 				if err != nil {
 					return nil, err
 				}
-				// FabricManager VIP is only supported in CSM 1.7 and later
+				// FabricManager VIP is only supported in CSM 1.7 and later AND requires FabricManager nodes
 				_, oneSevenCSM := csm.CompareMajorMinor("1.7")
-				if oneSevenCSM != -1 {
+				if oneSevenCSM != -1 && conf.HasFabricManagerNodes {
 					_, err = networking.AddReservation(
 						subnet,
 						"fmn-vip",
@@ -773,9 +774,9 @@ func createNetFromLayoutConfig(conf NetworkLayoutConfiguration) (network *networ
 				}
 			}
 			if tempNet.Name == "HMN" {
-				// FabricManager VIP is only supported in CSM 1.7 and later
+				// FabricManager VIP is only supported in CSM 1.7 and later AND requires FabricManager nodes
 				_, oneSevenCSM := csm.CompareMajorMinor("1.7")
-				if oneSevenCSM != -1 {
+				if oneSevenCSM != -1 && conf.HasFabricManagerNodes {
 					_, err = networking.AddReservation(
 						subnet,
 						"fmn-vip",


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMNET-2383](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2383)
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

This change prevents the creation of the fmn-virtual-ip reservation on systems that do not have Fabric Manager nodes.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
- [X] I tested this using a local development environment

#### Testing

Four test cases.

1. CSM 1.7.1 config with fabric manager nodes (surtur). fmn-virtual-ip should exist.
```
$ ./csi config init
...
$ grep fmn-virtual-ip surtur/sls_input_file.json
                                "Comment": "fmn-virtual-ip"
                                "Comment": "fmn-virtual-ip"
```
2. CSM 1.6 config with fabric nodes (surtur). fmn-virtual-ip should not exist.
```
$ ./csi config init --csm-version 1.6
...
$ grep fmn-virtual-ip surtur/sls_input_file.json
$
```
3. CSM 1.6 config without fabric manager nodes (wasp). fmn-virtual-ip should not exist.
```
$ ../../../csi config init
...
2025/12/02 15:42:23 [csm-version] was set to [v1.6]; All inputs are targeted for CSM v1.6
...
$ grep fmn-virtual-ip wasp/sls_input_file.json
$
```
4. CSM 1.7 config without fabric manager nodes (wasp). fmn-virtual-ip should not exist.
```
$ ../../../csi config init --csm-version 1.7
...
2025/12/02 15:43:09 [csm-version] was set to [v1.7]; All inputs are targeted for CSM v1.7
...
$ grep fmn-virtual-ip wasp/sls_input_file.json
$
```
 
### Idempotency
 
The change maintains idempotency as it performs a simple check for the presence of FabricManager nodes before conditionally creating the fmn-vip reservations. 
 
### Risks and Mitigations
 
This change reduces risk by preventing the creation of unnecessary IP reservations on systems without Fabric Manager nodes.